### PR TITLE
DS-1261 Make the return of properties optional

### DIFF
--- a/conf/log4j2-dev.xml
+++ b/conf/log4j2-dev.xml
@@ -136,6 +136,7 @@
     </Logger>
 
     <!-- project logging -->
+    <Logger name="com.visitscotland.brxm.utils.EnvironmentManager" level="info"/>
     <Logger name="com.visitscotland.brxm" level="debug"/>
 
     <Root level="warn">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/gtm.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/gtm.ftl
@@ -6,7 +6,7 @@
 <#macro gtm noscript=false >
     <#if (!editMode) >
         <#assign id= property("gtm.container-id")>
-        <#assign queryString = (property("gtm.is-production")?boolean)?then("", (property("gtm.preview-query-string"))) >
+        <#assign queryString = (property("gtm.is-production").get()?boolean)?then("", (property("gtm.preview-query-string"))) >
 
         <!-- Google Tag Manager -->
         <#if noscript >

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/gtm.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/gtm.ftl
@@ -5,7 +5,7 @@
 -->
 <#macro gtm noscript=false >
     <#if (!editMode) >
-        <#assign id= property("gtm.container-id")>
+        <#assign id= property("gtm.container-id").orElse("")>
         <#assign queryString = (property("gtm.is-production").orElseThrow()?boolean)?then("", (property("gtm.preview-query-string"))) >
 
         <!-- Google Tag Manager -->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/gtm.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/gtm.ftl
@@ -6,7 +6,7 @@
 <#macro gtm noscript=false >
     <#if (!editMode) >
         <#assign id= property("gtm.container-id")>
-        <#assign queryString = (property("gtm.is-production").get()?boolean)?then("", (property("gtm.preview-query-string"))) >
+        <#assign queryString = (property("gtm.is-production").orElseThrow()?boolean)?then("", (property("gtm.preview-query-string"))) >
 
         <!-- Google Tag Manager -->
         <#if noscript >

--- a/site/components/src/main/java/com/visitscotland/brxm/dms/DMSProxy.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/dms/DMSProxy.java
@@ -95,7 +95,7 @@ public class DMSProxy {
             HttpURLConnection dmsConnection = openConnection(properties.getDmsDataHost() + path);
             dmsConnection.setConnectTimeout(properties.getDmsTimeout());
             dmsConnection.setReadTimeout(properties.getDmsTimeout());
-            dmsConnection.setRequestProperty(HEADER, properties.getDmsToken());
+            properties.getDmsToken().ifPresent((token) -> dmsConnection.setRequestProperty(HEADER, token));
             dmsConnection.setRequestMethod("GET");
 
             int code = dmsConnection.getResponseCode();

--- a/site/components/src/main/java/com/visitscotland/brxm/hippobeans/BaseDocument.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/hippobeans/BaseDocument.java
@@ -32,15 +32,15 @@ public class BaseDocument extends HippoDocument {
      */
     @SuppressWarnings("unchecked")
     protected <T extends HippoBean> List<T> getMedia(String childNodeName) {
-        return (List<T>) getChildBeansByName(childNodeName, HippoBean.class).stream().map(hippoBean -> {
-                // TODO: Replace block with the following line
-                // (hippoBean instanceof HippoMirror ? ((HippoMirror) hippoBean).getReferencedBean() : hippoBean)
-                    if (hippoBean instanceof HippoMirror) {
-                        return ((HippoMirror) hippoBean).getReferencedBean();
-                    }
-                    return hippoBean;
-                }
-        ).collect(Collectors.toList());
+        return (List<T>) getChildBeansByName(childNodeName, HippoBean.class).stream().map(this::getBeans)
+        .collect(Collectors.toList());
+    }
+
+    private HippoBean getBeans(final HippoBean hippoBean) {
+        if (hippoBean instanceof HippoMirror) {
+            return ((HippoMirror) hippoBean).getReferencedBean();
+        }
+        return hippoBean;
     }
 
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/hippobeans/BaseDocument.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/hippobeans/BaseDocument.java
@@ -32,26 +32,15 @@ public class BaseDocument extends HippoDocument {
      */
     @SuppressWarnings("unchecked")
     protected <T extends HippoBean> List<T> getMedia(String childNodeName) {
-        return (List<T>) getChildBeansByName(childNodeName, HippoBean.class).stream().map(this::getBeans)
+        return (List<T>) getChildBeansByName(childNodeName, HippoBean.class).stream().map(this::getResolvedBean)
         .collect(Collectors.toList());
     }
 
-// In BaseDocument.java, rename the helper and update its usage
-
-// Before
-- private HippoBean getBeans(final HippoBean hippoBean) {
-+ private HippoBean getResolvedBean(final HippoBean hippoBean) {
-    if (hippoBean instanceof HippoMirror) {
-        return ((HippoMirror) hippoBean).getReferencedBean();
+    // In BaseDocument.java, rename the helper and update its usage
+    private HippoBean getResolvedBean(final HippoBean hippoBean) {
+        if (hippoBean instanceof HippoMirror) {
+            return ((HippoMirror) hippoBean).getReferencedBean();
+        }
+        return hippoBean;
     }
-    return hippoBean;
-}
-
-// And later where it’s used:
-- return (List<T>) getChildBeansByName(childNodeName, HippoBean.class).stream().map(this::getBeans)
-+ return (List<T>) getChildBeansByName(childNodeName, HippoBean.class)
-+     .stream()
-+     .map(this::getResolvedBean)
-    }
-
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/hippobeans/BaseDocument.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/hippobeans/BaseDocument.java
@@ -36,11 +36,22 @@ public class BaseDocument extends HippoDocument {
         .collect(Collectors.toList());
     }
 
-    private HippoBean getBeans(final HippoBean hippoBean) {
-        if (hippoBean instanceof HippoMirror) {
-            return ((HippoMirror) hippoBean).getReferencedBean();
-        }
-        return hippoBean;
+// In BaseDocument.java, rename the helper and update its usage
+
+// Before
+- private HippoBean getBeans(final HippoBean hippoBean) {
++ private HippoBean getResolvedBean(final HippoBean hippoBean) {
+    if (hippoBean instanceof HippoMirror) {
+        return ((HippoMirror) hippoBean).getReferencedBean();
+    }
+    return hippoBean;
+}
+
+// And later where it’s used:
+- return (List<T>) getChildBeansByName(childNodeName, HippoBean.class).stream().map(this::getBeans)
++ return (List<T>) getChildBeansByName(childNodeName, HippoBean.class)
++     .stream()
++     .map(this::getResolvedBean)
     }
 
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/services/ResourceBundleService.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/services/ResourceBundleService.java
@@ -177,7 +177,6 @@ public class ResourceBundleService {
                }
           } catch (MissingResourceException e) {
               // The resource bundle does not exist, the default file will be used instead
-              logger.debug("The resource bundle {}.{} does not exist", properties.getSiteId(), bundleName);
           }
         }
         return false;

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
@@ -58,8 +58,8 @@ public class CMSProperties extends Properties {
 
     static final String CMS_BASE_PATH = "links.cms-base-path.url";
 
-    public CMSProperties(ResourceBundleService bundle, HippoUtilsService utils, EnvironmentManager envrionmentManager) {
-        super(bundle, utils, envrionmentManager);
+    public CMSProperties(ResourceBundleService bundle, HippoUtilsService utils, EnvironmentManager environmentManager) {
+        super(bundle, utils, environmentManager);
     }
 
     @Override
@@ -196,8 +196,8 @@ public class CMSProperties extends Properties {
             if (value.isPresent()) {
                 return Charset.forName(value.get());
             }
-        } catch (RuntimeException e) {
-            logger.warn("{} is not a valid value for the property {}", value, DMS_DATA_ENCODING);
+        } catch (IllegalArgumentException | UnsupportedOperationException e) {
+            logger.warn("{} is not a valid value for the property {}", value.orElse(""), DMS_DATA_ENCODING);
         }
         return StandardCharsets.UTF_8;
     }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
@@ -58,8 +58,8 @@ public class CMSProperties extends Properties {
 
     static final String CMS_BASE_PATH = "links.cms-base-path.url";
 
-    public CMSProperties(ResourceBundleService bundle, HippoUtilsService utils) {
-        super(bundle, utils);
+    public CMSProperties(ResourceBundleService bundle, HippoUtilsService utils, EnvironmentManager envrionmentManager) {
+        super(bundle, utils, envrionmentManager);
     }
 
     @Override

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
@@ -171,6 +171,10 @@ public class CMSProperties extends Properties {
      */
     public Integer getContentCacheMaxElements() {
         int size = readInteger(CONTENT_CACHE_MAX_ELEMENTS);
+        if (size <= 0) {
+           logger.warn("Invalid or missing value for {}, defaulting to no limit", CONTENT_CACHE_MAX_ELEMENTS);
+           return Integer.MAX_VALUE;
+        }
         return size > 0 ? size : Integer.MAX_VALUE;
     }
 
@@ -196,7 +200,8 @@ public class CMSProperties extends Properties {
             if (value.isPresent()) {
                 return Charset.forName(value.get());
             }
-        } catch (IllegalArgumentException | UnsupportedOperationException e) {
+
+        } catch (IllegalArgumentException e) {
             logger.warn("{} is not a valid value for the property {}", value.orElse(""), DMS_DATA_ENCODING);
         }
         return StandardCharsets.UTF_8;

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
@@ -196,7 +196,7 @@ public class CMSProperties extends Properties {
             if (value.isPresent()) {
                 return Charset.forName(value.get());
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.warn("{} is not a valid value for the property {}", value, DMS_DATA_ENCODING);
         }
         return StandardCharsets.UTF_8;

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 @Component
 public class CMSProperties extends Properties {
@@ -190,10 +191,10 @@ public class CMSProperties extends Properties {
     }
 
     public Charset getDmsEncoding() {
-        String value = getProperty(DMS_DATA_ENCODING);
+        Optional<String> value = getProperty(DMS_DATA_ENCODING);
         try {
-            if (!Contract.isEmpty(value)) {
-                return Charset.forName(value);
+            if (value.isPresent()) {
+                return Charset.forName(value.get());
             }
         } catch (Exception e) {
             logger.warn("{} is not a valid value for the property {}", value, DMS_DATA_ENCODING);

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/CMSProperties.java
@@ -121,8 +121,8 @@ public class CMSProperties extends Properties {
         return readString(DMS_DATA_PUBLIC_HOST);
     }
 
-    public String getDmsToken() {
-        return readString(DMS_DATA_API_KEY);
+    public Optional<String> getDmsToken() {
+        return getProperty(DMS_DATA_API_KEY);
     }
 
     public Integer getDmsTimeout() {
@@ -170,7 +170,7 @@ public class CMSProperties extends Properties {
      * Max number of elements cached. If the property is not defined in the CMS, there is no maximum
      */
     public Integer getContentCacheMaxElements() {
-        Integer size = readInteger(CONTENT_CACHE_MAX_ELEMENTS);
+        int size = readInteger(CONTENT_CACHE_MAX_ELEMENTS);
         return size > 0 ? size : Integer.MAX_VALUE;
     }
 

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
@@ -1,0 +1,20 @@
+package com.visitscotland.brxm.utils;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@NonTestable(value = NonTestable.Cause.WRAP)
+public class EnvironmentManager {
+
+    String getEnvironmentVariable(String name){
+        try {
+            return System.getenv(name);
+        } catch (RuntimeException e){
+            return null;
+        }
+    }
+
+    String getSystemProperty(String name){
+        return System.getProperty(name, "");
+    }
+}

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
@@ -1,20 +1,33 @@
 package com.visitscotland.brxm.utils;
 
+import com.visitscotland.utils.Contract;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 @NonTestable(value = NonTestable.Cause.WRAP)
 public class EnvironmentManager {
 
-    String getEnvironmentVariable(String name){
+
+    Optional<String> getEnvironmentVariable(String name) {
         try {
-            return System.getenv(name);
+            String value = System.getenv(name);
+            if (!Contract.isEmpty(value)){
+                return Optional.of(value);
+            }
         } catch (RuntimeException e){
-            return null;
+
         }
+        return Optional.empty();
     }
 
-    String getSystemProperty(String name){
-        return System.getProperty(name, "");
+    Optional<String> getSystemProperty(String name){
+        String value = System.getProperty(name, "");
+        if (value.isEmpty()){
+            return Optional.empty();
+        } else {
+            return Optional.of(value);
+        }
     }
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
@@ -1,17 +1,17 @@
 package com.visitscotland.brxm.utils;
 
-import com.visitscotland.brxm.dms.DMSProxy;
 import com.visitscotland.utils.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 @Component
 public class EnvironmentManager {
 
-    private static final Logger logger = LoggerFactory.getLogger(DMSProxy.class);
+    private static final Logger logger = LoggerFactory.getLogger(EnvironmentManager.class);
 
     final SystemWrapper system;
 
@@ -19,28 +19,22 @@ public class EnvironmentManager {
         this.system = system;
     }
 
-
     Optional<String> getEnvironmentVariable(String name) {
-        try {
-            var value = system.getenv(name);
-            if (!Contract.isEmpty(value)){
-                return Optional.of(value);
-            }
-        } catch (NullPointerException | SecurityException e){
-            logger.debug("The environment Variable {} could not be read due to the following error: {}", name, e.getMessage());
-        }
-        return Optional.empty();
+        return readSystemValue(system::getProperty, name, "Environment Variable");
     }
 
     Optional<String> getSystemProperty(String name){
+        return readSystemValue(system::getProperty, name, "System property");
+    }
+
+    private Optional<String> readSystemValue(Function<String, String> retriever, String parameter, String type){
         try {
-            var value = system.getProperty(name);
+            var value = system.getProperty(retriever.apply(parameter));
             if (!Contract.isEmpty(value)){
                 return Optional.of(value);
             }
         } catch (NullPointerException | SecurityException e){
-            logger.debug("The system property {} could not be read due to the following error: {}", name, e.getMessage());
-            // If the variable does not exist or cannot be accessed the error is ignored and an empty value is returned
+            logger.debug("Cannot read {} {}: {}", type, parameter, e.getMessage());
         }
         return Optional.empty();
     }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
@@ -6,28 +6,30 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 
 @Component
-@NonTestable(value = NonTestable.Cause.WRAP)
 public class EnvironmentManager {
 
-
+    @NonTestable(value = NonTestable.Cause.WRAP)
     Optional<String> getEnvironmentVariable(String name) {
         try {
-            String value = System.getenv(name);
+            var value = System.getenv(name);
             if (!Contract.isEmpty(value)){
                 return Optional.of(value);
             }
         } catch (RuntimeException e){
-
+            // If the variable does not exist or cannot be accessed the error is ignored and an empty value is returned
         }
         return Optional.empty();
     }
 
     Optional<String> getSystemProperty(String name){
-        String value = System.getProperty(name, "");
-        if (value.isEmpty()){
-            return Optional.empty();
-        } else {
-            return Optional.of(value);
+        try {
+            var value = System.getProperty(name, "");
+            if (!Contract.isEmpty(value)){
+                return Optional.of(value);
+            }
+        } catch (RuntimeException e){
+            // If the variable does not exist or cannot be accessed the error is ignored and an empty value is returned
         }
+        return Optional.empty();
     }
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/EnvironmentManager.java
@@ -1,6 +1,9 @@
 package com.visitscotland.brxm.utils;
 
+import com.visitscotland.brxm.dms.DMSProxy;
 import com.visitscotland.utils.Contract;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -8,26 +11,35 @@ import java.util.Optional;
 @Component
 public class EnvironmentManager {
 
-    @NonTestable(value = NonTestable.Cause.WRAP)
+    private static final Logger logger = LoggerFactory.getLogger(DMSProxy.class);
+
+    final SystemWrapper system;
+
+    public EnvironmentManager(final SystemWrapper system) {
+        this.system = system;
+    }
+
+
     Optional<String> getEnvironmentVariable(String name) {
         try {
-            var value = System.getenv(name);
+            var value = system.getenv(name);
             if (!Contract.isEmpty(value)){
                 return Optional.of(value);
             }
-        } catch (RuntimeException e){
-            // If the variable does not exist or cannot be accessed the error is ignored and an empty value is returned
+        } catch (NullPointerException | SecurityException e){
+            logger.debug("The environment Variable {} could not be read due to the following error: {}", name, e.getMessage());
         }
         return Optional.empty();
     }
 
     Optional<String> getSystemProperty(String name){
         try {
-            var value = System.getProperty(name, "");
+            var value = system.getProperty(name);
             if (!Contract.isEmpty(value)){
                 return Optional.of(value);
             }
-        } catch (RuntimeException e){
+        } catch (NullPointerException | SecurityException e){
+            logger.debug("The system property {} could not be read due to the following error: {}", name, e.getMessage());
             // If the variable does not exist or cannot be accessed the error is ignored and an empty value is returned
         }
         return Optional.empty();

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/PageTemplateBuilder.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/PageTemplateBuilder.java
@@ -176,8 +176,8 @@ public class PageTemplateBuilder {
         Map<String, String> formLabels = labels(request).get("forms");
 
         //The following files are required independent of the Form Framework
-        formLabels.put("cfg.form.json.countries", properties.getProperty("form.json.countries"));
-        formLabels.put("cfg.form.json.messages", properties.getProperty("form.json.messages"));
+        formLabels.put("cfg.form.json.countries", properties.getProperty("form.json.countries").orElse(""));
+        formLabels.put("cfg.form.json.messages", properties.getProperty("form.json.messages").orElse(""));
 
         if (form instanceof MarketoForm) {
             return formFactory.getModule((MarketoForm) form);

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -132,9 +132,12 @@ public abstract class Properties {
 
         if (value == null) {
             return Optional.empty();
-        } else if (value.startsWith("$")){
+        } else if (value.equals("$") || value.equals("%")) {
+            logger.warn("Property {} contains an incomplete environment/system reference", key);
+            return Optional.empty();
+        } else if (value.startsWith("$") && value.length() > 1){
             return environmentManager.getEnvironmentVariable(value.substring(1));
-        } else if (value.startsWith("%")){
+        } else if (value.startsWith("%") && value.length() > 1){
             return environmentManager.getSystemProperty(value.substring(1));
         } else if (Contract.isEmpty(value)) {
             return Optional.empty();

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -52,7 +52,7 @@ public abstract class Properties {
             try {
                 return Integer.parseInt(value.get());
             } catch (NumberFormatException nfe) {
-                logger.error("The property value of the property {} cannot be cast to Integer. '{}' is not allowed.", key, value);
+                logger.error("The property value of the property {} cannot be cast to Integer. '{}' is not allowed.", key, value.get());
             }
         } else {
             logIssueWithProperty(key);
@@ -67,7 +67,7 @@ public abstract class Properties {
             try {
                 return Double.parseDouble(value.get());
             } catch (NumberFormatException nfe){
-                logger.error("The property value of the property {} cannot be cast to Double. '{}' is not allowed.", key,value);
+                logger.error("The property value of the property {} cannot be cast to Double. '{}' is not allowed.", key,value.get());
             }
         } else {
             logIssueWithProperty(key);

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -128,7 +128,7 @@ public abstract class Properties {
         String bundleId = getEnvironmentProperties();
         String value = readValueFromResourceBundle(key, locale, bundleId);
 
-        if (Contract.isEmpty(value)) {
+        if (value == null) {
             return Optional.empty();
         } else if (value.startsWith("$")){
             value = getEnvironmentVariable(value.substring(1));
@@ -136,7 +136,7 @@ public abstract class Properties {
             value = getSystemProperty(value.substring(1));
         }
 
-        return Optional.of(value);
+        return Contract.isEmpty(value) ? Optional.empty() : Optional.of(value);
     }
 
 

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -43,7 +43,7 @@ public abstract class Properties {
     }
 
     public Optional<String> readOptionalString(String key){
-        return getProperty(key);
+        return getProperty(key, DEFAULT_LOCALE);
     }
 
 
@@ -154,20 +154,22 @@ public abstract class Properties {
      */
     private String readValueFromResourceBundle(String key, Locale locale, String bundleId){
 
+        // The optional feature would be handled by this class rather than the resource bundle
+        final boolean optional = true;
         boolean defaultConfig = bundleId.equals(getDefaultConfig());
         boolean englishLocale = Locale.UK.equals(locale);
 
-        String value = bundle.getResourceBundle(bundleId, key, locale, !defaultConfig || !englishLocale);
+        String value = bundle.getResourceBundle(bundleId, key, locale, optional);
 
         if (Contract.isEmpty(value)) {
 
             if (!englishLocale) {
-                value = bundle.getResourceBundle(bundleId, key, Locale.UK, !defaultConfig );
+                value = bundle.getResourceBundle(bundleId, key, Locale.UK, optional);
             }
             if (Contract.isEmpty(value) && !defaultConfig) {
-                value = bundle.getResourceBundle(getDefaultConfig(), key,locale, !englishLocale);
+                value = bundle.getResourceBundle(getDefaultConfig(), key,locale, optional);
                 if (Contract.isEmpty(value) && !englishLocale){
-                    value = bundle.getResourceBundle(getDefaultConfig(), key,Locale.UK, false);
+                    value = bundle.getResourceBundle(getDefaultConfig(), key,Locale.UK, optional);
                 }
             }
         }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -115,7 +115,7 @@ public abstract class Properties {
 
     //TODO Reduce visibility to protected after VS-343
     public Optional<String> getProperty(String key){
-        return getProperty(key, Locale.UK);
+        return getProperty(key, DEFAULT_LOCALE);
     }
 
     //TODO Reduce visibility to protected after VS-343

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -52,7 +52,7 @@ public abstract class Properties {
             try {
                 return Integer.parseInt(value.get());
             } catch (NumberFormatException nfe) {
-                logger.error("The property value of the property {} cannot be casted to Integer. '{}' is not allowed.", key, value);
+                logger.error("The property value of the property {} cannot be cast to Integer. '{}' is not allowed.", key, value);
             }
         } else {
             logIssueWithProperty(key);
@@ -67,7 +67,7 @@ public abstract class Properties {
             try {
                 return Double.parseDouble(value.get());
             } catch (NumberFormatException nfe){
-                logger.error("The property value of the property {} cannot be casted to Double. '{}' is not allowed.", key,value);
+                logger.error("The property value of the property {} cannot be cast to Double. '{}' is not allowed.", key,value);
             }
         } else {
             logIssueWithProperty(key);

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -136,6 +136,8 @@ public abstract class Properties {
             return environmentManager.getEnvironmentVariable(value.substring(1));
         } else if (value.startsWith("%")){
             return environmentManager.getSystemProperty(value.substring(1));
+        } else if (Contract.isEmpty(value)) {
+            return Optional.empty();
         } else {
             return Optional.of(value);
         }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -8,10 +8,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
+import java.util.Optional;
 
 public abstract class Properties {
 
     private static final Logger logger = LoggerFactory.getLogger(Properties.class.getName());
+    private static final Locale DEFAULT_LOCALE = Locale.UK;
 
     private final ResourceBundleService bundle;
     private final HippoUtilsService utils;
@@ -26,51 +28,58 @@ public abstract class Properties {
     abstract String getOverrideProperty();
 
     public String readString(String key){
-        String value = getProperty(key);
-        if (value != null){
-            return value;
-        } else {
-            return "";
-        }
+        return readString(key, DEFAULT_LOCALE);
     }
 
     public String readString(String key, Locale locale){
-        String value = getProperty(key, locale);
-        if (value != null){
-            return value;
-        } else {
-            return getProperty(key);
-        }
+        return getProperty(key, locale).orElseGet(() ->
+                getProperty(key).orElseGet(() -> {
+                    logIssueWithProperty(key);
+                    return "";
+                })
+        );
     }
 
-    public int readInteger(String key){
-        String value = getProperty(key);
+    public Optional<String> readOptionalString(String key){
+        return getProperty(key);
+    }
 
-        try {
-            if (value != null){
-                return Integer.parseInt(value);
+
+    public int readInteger(String key){
+        Optional<String> value = getProperty(key);
+
+        if (value.isPresent()) {
+            try {
+                return Integer.parseInt(value.get());
+            } catch (NumberFormatException nfe) {
+                logger.error("The property value of the property {} cannot be casted to Integer. '{}' is not allowed.", key, value);
             }
-        } catch (NumberFormatException nfe){
-            logger.error("The property value of the property {} cannot be casted to Integer. '{}' is not allowed.", key,value);
+        } else {
+            logIssueWithProperty(key);
         }
         return 0;
     }
 
     public double readDouble(String key){
-        String value = getProperty(key);
+        Optional<String> value = getProperty(key);
 
-        try {
-            if (value != null){
-                return Double.parseDouble(value);
+        if (value.isPresent()){
+            try {
+                return Double.parseDouble(value.get());
+            } catch (NumberFormatException nfe){
+                logger.error("The property value of the property {} cannot be casted to Double. '{}' is not allowed.", key,value);
             }
-        } catch (NumberFormatException nfe){
-            logger.error("The property value of the property {} cannot be casted to Double. '{}' is not allowed.", key,value);
+        } else {
+            logIssueWithProperty(key);
         }
         return 0;
     }
 
     public boolean readBoolean(String key){
-        return Boolean.parseBoolean(getProperty(key));
+        return Boolean.parseBoolean(getProperty(key).orElseGet(() -> {
+            logIssueWithProperty(key);
+            return "false";
+        }));
     }
 
     /**
@@ -98,16 +107,49 @@ public abstract class Properties {
         return getDefaultConfig();
     }
 
-    public String getProperty(String key){
+    private void logIssueWithProperty (String key) {
+        logger.info("The property {} hasn't been set in the resourceBundle", key);
+    }
+
+    //TODO Reduce visibility to protected after DS-XXX
+    public Optional<String> getProperty(String key){
         return getProperty(key, Locale.UK);
     }
 
-    public String getProperty(String key, String locale){
+    //TODO Reduce visibility to protected after DS-XXX
+    public  Optional<String> getProperty(String key, String locale){
         return getProperty(key, Locale.forLanguageTag(locale));
     }
 
-    public String getProperty(String key, Locale locale){
+    //TODO Reduce visibility to protected after DS-XXX
+    public Optional<String> getProperty(String key, Locale locale){
         String bundleId = getEnvironmentProperties();
+        String value = readValueFromResourceBundle(key, locale, bundleId);
+
+        if (Contract.isEmpty(value)) {
+            return Optional.empty();
+        } else if (value.startsWith("$")){
+            value = getEnvironmentVariable(value.substring(1));
+        } else if (value.startsWith("%")){
+            value = getSystemProperty(value.substring(1));
+        }
+
+        return Optional.of(value);
+    }
+
+
+    /**
+     * Reads a value from a Hippo resource bundle using the specified key, locale, and bundle ID.
+     * Attempts to fall back to the default locale if the key is not found for the provided locale.
+     * If the site-specific properties are undefined, it defaults to general properties.
+     *
+     * @param key       the property key to retrieve
+     * @param locale    the locale to use for lookup
+     * @param bundleId  the identifier of the resource bundle
+     * @return the resolved property value, or null if not found
+     */
+    private String readValueFromResourceBundle(String key, Locale locale, String bundleId){
+
         boolean defaultConfig = bundleId.equals(getDefaultConfig());
         boolean englishLocale = Locale.UK.equals(locale);
 
@@ -126,17 +168,7 @@ public abstract class Properties {
             }
         }
 
-        if (Contract.isEmpty(value)) {
-            logger.info("The property {} hasn't been set in the resourceBundle {}", key, bundleId);
-        } else if (value.startsWith("$")){
-            return getEnvironmentVariable(value.substring(1));
-        } else if (value.startsWith("%")){
-            return getSystemProperty(value.substring(1));
-        } else {
-            return value;
-        }
-
-        return null;
+        return value;
     }
 
     String getEnvironmentVariable(String name){

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -133,12 +133,12 @@ public abstract class Properties {
         if (value == null) {
             return Optional.empty();
         } else if (value.startsWith("$")){
-            value = environmentManager.getEnvironmentVariable(value.substring(1));
+            return environmentManager.getEnvironmentVariable(value.substring(1));
         } else if (value.startsWith("%")){
-            value = environmentManager.getSystemProperty(value.substring(1));
+            return environmentManager.getSystemProperty(value.substring(1));
+        } else {
+            return Optional.of(value);
         }
-
-        return Contract.isEmpty(value) ? Optional.empty() : Optional.of(value);
     }
 
 

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -156,8 +156,8 @@ public abstract class Properties {
 
         // The optional feature would be handled by this class rather than the resource bundle
         final boolean optional = true;
-        boolean defaultConfig = bundleId.equals(getDefaultConfig());
-        boolean englishLocale = Locale.UK.equals(locale);
+        final boolean defaultConfig = bundleId.equals(getDefaultConfig());
+        final boolean englishLocale = Locale.UK.equals(locale);
 
         String value = bundle.getResourceBundle(bundleId, key, locale, optional);
 

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -111,17 +111,19 @@ public abstract class Properties {
         logger.info("The property {} hasn't been set in the resourceBundle", key);
     }
 
-    //TODO Reduce visibility to protected after DS-XXX
+    //TODO Reduce visibility to protected after VS-343
     public Optional<String> getProperty(String key){
         return getProperty(key, Locale.UK);
     }
 
-    //TODO Reduce visibility to protected after DS-XXX
+    //TODO Reduce visibility to protected after VS-343
+    //TODO Remove method only used in FreeMarker
+    @Deprecated(since="2.10.0")
     public  Optional<String> getProperty(String key, String locale){
         return getProperty(key, Locale.forLanguageTag(locale));
     }
 
-    //TODO Reduce visibility to protected after DS-XXX
+    //TODO Reduce visibility to protected after VS-343
     public Optional<String> getProperty(String key, Locale locale){
         String bundleId = getEnvironmentProperties();
         String value = readValueFromResourceBundle(key, locale, bundleId);

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/Properties.java
@@ -17,10 +17,12 @@ public abstract class Properties {
 
     private final ResourceBundleService bundle;
     private final HippoUtilsService utils;
+    private final EnvironmentManager environmentManager;
 
-    protected Properties(ResourceBundleService bundle, HippoUtilsService utils){
+    protected Properties(ResourceBundleService bundle, HippoUtilsService utils, EnvironmentManager environmentManager){
         this.bundle = bundle;
         this.utils = utils;
+        this.environmentManager = environmentManager;
     }
 
     abstract String getDefaultConfig();
@@ -131,9 +133,9 @@ public abstract class Properties {
         if (value == null) {
             return Optional.empty();
         } else if (value.startsWith("$")){
-            value = getEnvironmentVariable(value.substring(1));
+            value = environmentManager.getEnvironmentVariable(value.substring(1));
         } else if (value.startsWith("%")){
-            value = getSystemProperty(value.substring(1));
+            value = environmentManager.getSystemProperty(value.substring(1));
         }
 
         return Contract.isEmpty(value) ? Optional.empty() : Optional.of(value);
@@ -171,17 +173,5 @@ public abstract class Properties {
         }
 
         return value;
-    }
-
-    String getEnvironmentVariable(String name){
-        try {
-            return System.getenv(name);
-        } catch (RuntimeException e){
-            return null;
-        }
-    }
-
-    String getSystemProperty(String name){
-        return System.getProperty(name, "");
     }
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
@@ -157,7 +157,7 @@ public class SiteProperties extends Properties {
     }
 
     public String getSiteId() {
-        return readString(SITE_ID);
+        return readOptionalString(SITE_ID).orElse(null);
     }
 
     public String getFormBregLegalBasis() {

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
@@ -157,7 +157,7 @@ public class SiteProperties extends Properties {
     }
 
     public String getSiteId() {
-        return readOptionalString(SITE_ID).orElse(null);
+        return readOptionalString(SITE_ID).orElse("");
     }
 
     public String getFormBregLegalBasis() {

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
@@ -60,8 +60,8 @@ public class SiteProperties extends Properties {
     static final String FORM_BREG_LEGAL_BASIS_ENABLE = "form.breg.legal-basis.enable";
 
     private final CMSProperties cmsProperties;
-    public SiteProperties(ResourceBundleService bundle, HippoUtilsService utils, CMSProperties cmsProperties){
-        super(bundle, utils);
+    public SiteProperties(ResourceBundleService bundle, HippoUtilsService utils, CMSProperties cmsProperties,EnvironmentManager envrionmentManager) {
+        super(bundle, utils, envrionmentManager);
         this.cmsProperties = cmsProperties;
     }
 

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
@@ -60,7 +60,7 @@ public class SiteProperties extends Properties {
     static final String FORM_BREG_LEGAL_BASIS_ENABLE = "form.breg.legal-basis.enable";
 
     private final CMSProperties cmsProperties;
-    public SiteProperties(ResourceBundleService bundle, HippoUtilsService utils, CMSProperties cmsProperties,EnvironmentManager envrionmentManager) {
+    public SiteProperties(ResourceBundleService bundle, HippoUtilsService utils, CMSProperties cmsProperties, EnvironmentManager envrionmentManager) {
         super(bundle, utils, envrionmentManager);
         this.cmsProperties = cmsProperties;
     }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SystemWrapper.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SystemWrapper.java
@@ -11,6 +11,6 @@ public class SystemWrapper {
     }
 
     public String getProperty(String key) {
-        return System.getProperty(key, "");
+        return System.getProperty(key);
     }
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SystemWrapper.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SystemWrapper.java
@@ -1,0 +1,16 @@
+package com.visitscotland.brxm.utils;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@NonTestable(value = NonTestable.Cause.WRAP)
+public class SystemWrapper {
+
+    public String getenv(String key) {
+        return System.getenv(key);
+    }
+
+    public String getProperty(String key) {
+        return System.getProperty(key, "");
+    }
+}

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
@@ -2,28 +2,48 @@ package com.visitscotland.brxm.utils;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(MockitoExtension.class)
 class EnvironmentManagerTest {
 
-    private final EnvironmentManager manager = new EnvironmentManager();
+    @Mock SystemWrapper system;
+
+    @InjectMocks EnvironmentManager manager;
 
     @Test
     @DisplayName("System properties are read correctly")
     void when_systemPropertyExists_then_returnValue() {
-        System.setProperty("vs-property", "value");
+        Mockito.when(system.getProperty("vs-property")).thenReturn("value");
         assertEquals(Optional.of("value"), manager.getSystemProperty("vs-property"));
     }
 
     @Test
     @DisplayName("When system properties do not exist return Empty")
     void when_systemPropertyDoesNotExist_then_returnEmpty() {
-        System.clearProperty("vs-property");
         assertEquals(Optional.empty(), manager.getSystemProperty("vs-property"));
+    }
+
+    @Test
+    @DisplayName("When system properties throw an exception, return Empty")
+    void when_systemPropertyThrowsException_then_returnEmpty() {
+        Mockito.when(system.getProperty("vs-property")).thenThrow(NullPointerException.class);
+        assertEquals(Optional.empty(), manager.getSystemProperty("vs-property"));
+    }
+
+    @Test
+    @DisplayName("Environment variables are read correctly")
+    void when_environmentVariableExists_then_returnValue() {
+        Mockito.when(system.getenv("VAR_123456")).thenReturn("value");
+        assertEquals(Optional.of("value"), manager.getEnvironmentVariable("VAR_123456"));
     }
 
     @Test
@@ -31,5 +51,12 @@ class EnvironmentManagerTest {
     void when_environmentVariableDoesNotExist_then_returnEmpty() {
         Optional<String> result = manager.getEnvironmentVariable("VAR_123456");
         assertEquals(Optional.empty(), result);
+    }
+
+    @Test
+    @DisplayName("When Environment Variable throw an exception, return Empty")
+    void when_environmentVariableThrowsException_then_returnEmpty() {
+        Mockito.when(system.getenv("VAR_123456")).thenThrow(SecurityException.class);
+        assertEquals(Optional.empty(), manager.getEnvironmentVariable("VAR_123456"));
     }
 }

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EnvironmentManagerTest {
 
     private final EnvironmentManager manager = new EnvironmentManager();
-    private static final String NULL = null;
 
     @Test
     @DisplayName("System properties are read correctly")

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
@@ -1,0 +1,36 @@
+package com.visitscotland.brxm.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnvironmentManagerTest {
+
+    private final EnvironmentManager manager = new EnvironmentManager();
+    private static final String NULL = null;
+
+    @Test
+    @DisplayName("System properties are read correctly")
+    void when_systemPropertyExists_then_returnValue() {
+        System.setProperty("vs-property", "value");
+        assertEquals(Optional.of("value"), manager.getSystemProperty("vs-property"));
+    }
+
+    @Test
+    @DisplayName("When system properties do not exist return Empty")
+    void when_systemPropertyDoesNotExist_then_returnEmpty() {
+        System.clearProperty("vs-property");
+        assertEquals(Optional.empty(), manager.getSystemProperty("vs-property"));
+    }
+
+    @Test
+    @DisplayName("When environment variables do not exist return Empty")
+    void when_environmentVariableDoesNotExist_then_returnEmpty() {
+        Optional<String> result = manager.getEnvironmentVariable("VAR_123456");
+        assertTrue(result.isEmpty());
+    }
+}

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/EnvironmentManagerTest.java
@@ -30,6 +30,6 @@ class EnvironmentManagerTest {
     @DisplayName("When environment variables do not exist return Empty")
     void when_environmentVariableDoesNotExist_then_returnEmpty() {
         Optional<String> result = manager.getEnvironmentVariable("VAR_123456");
-        assertTrue(result.isEmpty());
+        assertEquals(Optional.empty(), result);
     }
 }

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/PropertiesTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/PropertiesTest.java
@@ -69,7 +69,6 @@ class PropertiesTest {
     @DisplayName("Empty values return an empty String for String properties")
     void readString_env(String value){
         when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, false)).thenReturn(value);
-        value = "";
         assertEquals("", properties.readString("string"));
     }
 
@@ -265,10 +264,10 @@ class PropertiesTest {
     @DisplayName("VS-3908 - The properties can have specific values for different locales")
     void locales(){
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("/site/site-search-results");
-        assertEquals("/site/site-search-results", properties.getProperty(PROPERTY_KEY));
+        assertEquals("/site/site-search-results", properties.getProperty(PROPERTY_KEY).orElseThrow());
 
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("/site/fr/site-search-results");
-        assertEquals("/site/fr/site-search-results", properties.getProperty(PROPERTY_KEY, Locale.FRANCE));
+        assertEquals("/site/fr/site-search-results", properties.getProperty(PROPERTY_KEY, Locale.FRANCE).orElseThrow());
     }
 
     @Test
@@ -276,7 +275,7 @@ class PropertiesTest {
     void locales_defaultEnglish(){
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("");
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("/site/site-search-results");
-        assertEquals("/site/site-search-results", properties.getProperty(PROPERTY_KEY, Locale.FRANCE));
+        assertEquals("/site/site-search-results", properties.getProperty(PROPERTY_KEY, Locale.FRANCE).orElseThrow());
     }
 
     @Test
@@ -286,7 +285,7 @@ class PropertiesTest {
         when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("");
         when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.UK, true)).thenReturn("");
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("555");
-        assertEquals("555", properties.getProperty(PROPERTY_KEY, Locale.FRANCE));
+        assertEquals("555", properties.getProperty(PROPERTY_KEY, Locale.FRANCE).orElseThrow());
     }
 
     @Test
@@ -297,7 +296,7 @@ class PropertiesTest {
         when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.UK, true)).thenReturn("");
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.JAPAN, true)).thenReturn("");
         when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("131");
-        assertEquals("131", properties.getProperty(PROPERTY_KEY, Locale.JAPAN));
+        assertEquals("131", properties.getProperty(PROPERTY_KEY, Locale.JAPAN).orElseThrow());
     }
 
 }

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/PropertiesTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/PropertiesTest.java
@@ -40,8 +40,6 @@ class PropertiesTest {
     @InjectMocks
     CMSProperties properties;
 
-    String value;
-
     @Test
     @DisplayName("Reads an String value from a property")
     void readString(){
@@ -219,7 +217,7 @@ class PropertiesTest {
     void propertyValues_defaultConfig(){
         when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, false)).thenReturn("PROP-VALUE");
 
-        assertEquals("PROP-VALUE", properties.getDmsToken());
+        assertEquals("PROP-VALUE", properties.getDmsToken().orElseThrow());
     }
 
     private final static String ENV_PROPERTIES = "environment-properties";
@@ -239,7 +237,7 @@ class PropertiesTest {
         //This is not expected to be called but if were, It shouldn't affect the outcome of the method
         lenient().when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, false)).thenReturn("DEFAULT-VALUE");
 
-        assertEquals("OVERRIDE-VALUE", properties.getDmsToken());
+        assertEquals("OVERRIDE-VALUE", properties.getDmsToken().orElseThrow());
     }
 
     @Test
@@ -251,7 +249,7 @@ class PropertiesTest {
         //This is not expected to be called but if were, It shouldn't affect the outcome of the method
         when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, false)).thenReturn("DEFAULT-VALUE");
 
-        assertEquals("DEFAULT-VALUE", properties.getDmsToken());
+        assertEquals("DEFAULT-VALUE", properties.getDmsToken().orElseThrow());
     }
 
     @Test

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/PropertiesTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/PropertiesTest.java
@@ -26,6 +26,7 @@ class PropertiesTest {
 
     final static String BUNDLE_ID = CMSProperties.DEFAULT_CONFIG;
     final static String PROPERTY_KEY = "property-key";
+    final static boolean OPTIONAL_RESOURCE_BUNDLE = true;
 
 
     @Mock
@@ -43,7 +44,7 @@ class PropertiesTest {
     @Test
     @DisplayName("Reads an String value from a property")
     void readString(){
-        when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, false)).thenReturn("http://localhost:8181");
+        when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("http://localhost:8181");
         assertEquals("http://localhost:8181", properties.readString("string"));
     }
 
@@ -51,7 +52,7 @@ class PropertiesTest {
     @DisplayName("Reads an string value from an environment variable")
     void readString_env(){
         final String value = "http://dms.visitscotland.com";
-        when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, false)).thenReturn("$TEST_VS");
+        when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("$TEST_VS");
         when(environmentManager.getEnvironmentVariable("TEST_VS")).thenReturn(Optional.of(value));
         assertEquals(value, properties.readString("string"));
     }
@@ -61,21 +62,21 @@ class PropertiesTest {
     @NullSource
     @DisplayName("Empty values return an empty String for String properties")
     void readString_env(String value){
-        when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, false)).thenReturn(value);
+        when(bundle.getResourceBundle(BUNDLE_ID, "string", Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(value);
         assertEquals("", properties.readString("string"));
     }
 
     @Test
     @DisplayName("Reads an integer number from a property")
     void readInteger(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_TRIES, Locale.UK, false)).thenReturn("3718");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_TRIES, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("3718");
         assertEquals(3718, properties.getDmsTries());
     }
 
     @Test
     @DisplayName("Can parse Integers from environment variables")
     void readInteger_env(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_TRIES, Locale.UK, false)).thenReturn("%TEST_VS");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_TRIES, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("%TEST_VS");
         when(environmentManager.getSystemProperty("TEST_VS")).thenReturn(Optional.of("3718"));
         assertEquals(3718, properties.getDmsTries());
     }
@@ -85,21 +86,21 @@ class PropertiesTest {
     @NullSource
     @DisplayName("Empty and wrong values return 0 for Numeric properties")
     void readInteger_empty(String value){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_TRIES, Locale.UK, false)).thenReturn(value);
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_TRIES, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(value);
         assertEquals(0, properties.getDmsTries());
     }
 
     @Test
     @DisplayName("Reads an integer number from a property")
     void readDouble(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_MAP_DEFAULT_DISTANCE, Locale.UK, false)).thenReturn("3.14");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_MAP_DEFAULT_DISTANCE, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("3.14");
         assertEquals(3.14, properties.getDmsMapDefaultDistance());
     }
 
     @Test
     @DisplayName("Can parse Integers from environment variables")
     void readDouble_env(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_MAP_DEFAULT_DISTANCE, Locale.UK, false)).thenReturn("%TEST_VS");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_MAP_DEFAULT_DISTANCE, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("%TEST_VS");
         when(environmentManager.getSystemProperty("TEST_VS")).thenReturn(Optional.of("3.14"));
         assertEquals(3.14, properties.getDmsMapDefaultDistance());
     }
@@ -109,7 +110,7 @@ class PropertiesTest {
     @NullSource
     @DisplayName("Empty and wrong values return 0 for Numeric properties")
     void readDouble_empty(String value){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_MAP_DEFAULT_DISTANCE, Locale.UK, false)).thenReturn(value);
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_MAP_DEFAULT_DISTANCE, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(value);
         assertEquals(0.0, properties.getDmsMapDefaultDistance());
     }
 
@@ -118,7 +119,7 @@ class PropertiesTest {
     @ValueSource(strings = {"true", "TRUE"})
     @DisplayName("Reads true from a property")
     void readBoolean(String value){
-        when(bundle.getResourceBundle(BUNDLE_ID, "boolean", Locale.UK, false)).thenReturn(value);
+        when(bundle.getResourceBundle(BUNDLE_ID, "boolean", Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(value);
         assertTrue(properties.readBoolean("boolean"));
     }
 
@@ -127,14 +128,14 @@ class PropertiesTest {
     @NullSource
     @DisplayName("false, empty and wrong values return false for Boolean properties")
     void readInteger_false(String value){
-        when(bundle.getResourceBundle(BUNDLE_ID, "boolean", Locale.UK, false)).thenReturn(value);
+        when(bundle.getResourceBundle(BUNDLE_ID, "boolean", Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(value);
         assertFalse(properties.readBoolean("boolean"));
     }
 
     @Test
     @DisplayName("getDmsEncoding - Can parse the value from a String")
     void getDmsEncoding(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_ENCODING, Locale.UK, false)).thenReturn("ISO-8859-1");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_ENCODING, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("ISO-8859-1");
         assertEquals(StandardCharsets.ISO_8859_1, properties.getDmsEncoding());
     }
 
@@ -143,29 +144,29 @@ class PropertiesTest {
     @NullSource
     @DisplayName("getDmsEncoding - non recognized values return UTF-8 encoding")
     void getDmsEncoding_empty(String value){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_ENCODING, Locale.UK, false)).thenReturn(value);
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_ENCODING, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(value);
         assertEquals(StandardCharsets.UTF_8, properties.getDmsEncoding());
     }
 
     @Test
     @DisplayName("As requested by WebOps, links to vs-dms-products URLs will be relative when use relative urls is active")
     void getDmsHost(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_HOST, Locale.UK, false)).thenReturn("http://test-dms.visitscotland.com");
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, false)).thenReturn("false");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_HOST, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("http://test-dms.visitscotland.com");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("false");
         assertEquals("http://test-dms.visitscotland.com", properties.getDmsHost());
 
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, false)).thenReturn("true");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("true");
         assertEquals("", properties.getDmsHost());
     }
 
     @Test
     @DisplayName("As requested by WebOps, made up links to the CMS, will be relative when use relative urls is active")
     void getLocalHost(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.CMS_BASE_PATH, Locale.UK, false)).thenReturn("http:/localhost:8080/site");
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, false)).thenReturn("true");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.CMS_BASE_PATH, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("http:/localhost:8080/site");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("true");
         assertEquals("", properties.getDmsHost());
 
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, false)).thenReturn("false");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.USE_RELATIVE_URLS, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("false");
         assertEquals("http:/localhost:8080/site", properties.getCmsBasePath());
     }
 
@@ -173,11 +174,11 @@ class PropertiesTest {
     @DisplayName("getInstagramURL() Composes the token from the app-id and the client-token (PR-383)")
     void getInstagramURL(){
 
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.INSTAGRAM_APP_ID, Locale.UK, false)).thenReturn("{app-id}");
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.INSTAGRAM_ACCESS_TOKEN, Locale.UK, false)).thenReturn("{client-token}");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.INSTAGRAM_APP_ID, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("{app-id}");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.INSTAGRAM_ACCESS_TOKEN, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("{client-token}");
         assertEquals("{app-id}|{client-token}", properties.getInstagramToken());
 
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.INSTAGRAM_ACCESS_TOKEN, Locale.UK, false)).thenReturn("");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.INSTAGRAM_ACCESS_TOKEN, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
         assertEquals("{app-id}", properties.getInstagramToken());
     }
 
@@ -215,7 +216,7 @@ class PropertiesTest {
     @Test
     @DisplayName("VS-3183 - Use default.config as the default properties given by the CMS from the codebase")
     void propertyValues_defaultConfig(){
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, false)).thenReturn("PROP-VALUE");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("PROP-VALUE");
 
         assertEquals("PROP-VALUE", properties.getDmsToken().orElseThrow());
     }
@@ -232,10 +233,10 @@ class PropertiesTest {
     @DisplayName("VS-3183 - Override properties when configured in the mount")
     void propertyValues_overrideConfig(){
         customizedProperties();
-        when(bundle.getResourceBundle(ENV_PROPERTIES, CMSProperties.DMS_DATA_API_KEY, Locale.UK, true)).thenReturn("OVERRIDE-VALUE");
+        when(bundle.getResourceBundle(ENV_PROPERTIES, CMSProperties.DMS_DATA_API_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("OVERRIDE-VALUE");
 
         //This is not expected to be called but if were, It shouldn't affect the outcome of the method
-        lenient().when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, false)).thenReturn("DEFAULT-VALUE");
+        lenient().when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("DEFAULT-VALUE");
 
         assertEquals("OVERRIDE-VALUE", properties.getDmsToken().orElseThrow());
     }
@@ -244,10 +245,10 @@ class PropertiesTest {
     @DisplayName("VS-3183 - If the property is not found in the file defined in the mount, it takes the value from default.config")
     void propertyValues_overrideConfig_defaultValue(){
         customizedProperties();
-        when(bundle.getResourceBundle(ENV_PROPERTIES, CMSProperties.DMS_DATA_API_KEY, Locale.UK, true)).thenReturn(null);
+        when(bundle.getResourceBundle(ENV_PROPERTIES, CMSProperties.DMS_DATA_API_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn(null);
 
         //This is not expected to be called but if were, It shouldn't affect the outcome of the method
-        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, false)).thenReturn("DEFAULT-VALUE");
+        when(bundle.getResourceBundle(BUNDLE_ID, CMSProperties.DMS_DATA_API_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("DEFAULT-VALUE");
 
         assertEquals("DEFAULT-VALUE", properties.getDmsToken().orElseThrow());
     }
@@ -255,18 +256,18 @@ class PropertiesTest {
     @Test
     @DisplayName("VS-3908 - The properties can have specific values for different locales")
     void locales(){
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("/site/site-search-results");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("/site/site-search-results");
         assertEquals("/site/site-search-results", properties.getProperty(PROPERTY_KEY).orElseThrow());
 
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("/site/fr/site-search-results");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("/site/fr/site-search-results");
         assertEquals("/site/fr/site-search-results", properties.getProperty(PROPERTY_KEY, Locale.FRANCE).orElseThrow());
     }
 
     @Test
     @DisplayName("VS-3908 - Properties in the language fallback to English")
     void locales_defaultEnglish(){
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("");
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("/site/site-search-results");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("/site/site-search-results");
         assertEquals("/site/site-search-results", properties.getProperty(PROPERTY_KEY, Locale.FRANCE).orElseThrow());
     }
 
@@ -274,9 +275,9 @@ class PropertiesTest {
     @DisplayName("VS-3908 - non-existing localized custom properties -> Localized global properties")
     void locales_overrideProperties(){
         customizedProperties();
-        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("");
-        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.UK, true)).thenReturn("");
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, true)).thenReturn("555");
+        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.FRANCE, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
+        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.FRANCE, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("555");
         assertEquals("555", properties.getProperty(PROPERTY_KEY, Locale.FRANCE).orElseThrow());
     }
 
@@ -284,17 +285,17 @@ class PropertiesTest {
     @DisplayName("VS-3908 - non-existing localized custom properties -> English global properties")
     void locales_overrideProperties_defaultEnglish(){
         customizedProperties();
-        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.JAPAN, true)).thenReturn("");
-        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.UK, true)).thenReturn("");
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.JAPAN, true)).thenReturn("");
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("131");
+        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.JAPAN, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
+        when(bundle.getResourceBundle(ENV_PROPERTIES, PROPERTY_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.JAPAN, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("131");
         assertEquals("131", properties.getProperty(PROPERTY_KEY, Locale.JAPAN).orElseThrow());
     }
 
     @Test
     @DisplayName("Optional fields can return the value")
     void when_optionalPropertyIsSet_then_returnValue(){
-        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, false)).thenReturn("131");
+        when(bundle.getResourceBundle(BUNDLE_ID, PROPERTY_KEY, Locale.UK, OPTIONAL_RESOURCE_BUNDLE)).thenReturn("131");
         assertTrue(properties.readOptionalString(PROPERTY_KEY).isPresent());
     }
 


### PR DESCRIPTION
This is an unintended piece of work.

The properties mechanisms was designed for only one site. Then it evolved to a freemarker site and a delivery API site and now we are in a moment where the main site with the default properties is also a Delivery API site

There were lots of warning/error messages in the console, which should be fixed with this changes.

This section had unit tests and they are all passing.