### PR TITLE
VS-1087 Feature Switch for global search

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/default-site-properties.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/default-site-properties.yaml
@@ -4,7 +4,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: ea5611a6-5160-4713-86e9-52334587567c
   hippo:name: Default - Site Properties
-  hippo:versionHistory: 0a132622-71a4-43f8-b821-a3f0db8534c7
+  hippo:versionHistory: 181d0800-7c0a-42f6-bffc-1254f11e4744
   /default-site-properties[1]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:versionable']
@@ -14,7 +14,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2025-12-18T18:02:45.579Z
+    hippostdpubwf:lastModificationDate: 2026-01-05T10:27:19.083Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed
@@ -45,7 +45,7 @@
       cludo.experience-id, feature.products-search.enable, feature.table-of-contents.enable,
       feature.global-search.enable, form.breg.legal-basis.text, site.path.icentre-landing,
       site-id, google-maps.api-key, site.path.map, feature.hero-section.enable, feature.global-search.events-endpoint,
-      feature.search-widget.enabled, feature.global-search.dms-based]
+      feature.global-search.dms-based, feature.search-widget.enable]
     resourcebundle:messages: ['https://community.visitscotland.com/', discussions/tagged/,
       'localhost,www.visitscotland.com,beta.visitscotland.com,blog.visitscotland.com',
       www.visitscotland.com, 'en,fr,de,nl,it,es', 'true', GTM-WQVX2V, '&gtm_auth=YWMt6gew5Au1PAnzyzMADQ&gtm_preview=env-3&gtm_cookies_win=x',
@@ -81,7 +81,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2025-12-18T17:51:37.458Z
+    hippostdpubwf:lastModificationDate: 2026-01-05T10:21:41.686Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed
@@ -112,7 +112,7 @@
       cludo.experience-id, feature.products-search.enable, feature.table-of-contents.enable,
       feature.global-search.enable, form.breg.legal-basis.text, site.path.icentre-landing,
       site-id, google-maps.api-key, site.path.map, feature.hero-section.enable, feature.global-search.events-endpoint,
-      feature.search-widget.enabled, feature.global-search.dms-based]
+      feature.global-search.dms-based, feature.search-widget.enable]
     resourcebundle:messages: ['https://community.visitscotland.com/', discussions/tagged/,
       'localhost,www.visitscotland.com,beta.visitscotland.com,blog.visitscotland.com',
       www.visitscotland.com, 'en,fr,de,nl,it,es', 'true', GTM-WQVX2V, '&gtm_auth=YWMt6gew5Au1PAnzyzMADQ&gtm_preview=env-3&gtm_cookies_win=x',
@@ -148,9 +148,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2025-12-18T15:49:26.265Z
+    hippostdpubwf:lastModificationDate: 2026-01-05T10:27:19.083Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2025-12-18T15:49:31.349Z
+    hippostdpubwf:publicationDate: 2026-01-05T10:27:22.788Z
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed
         into Relative URLs when the value of attribute 'links.use-relative-urls is
@@ -180,7 +180,7 @@
       cludo.experience-id, feature.products-search.enable, feature.table-of-contents.enable,
       feature.global-search.enable, form.breg.legal-basis.text, site.path.icentre-landing,
       site-id, google-maps.api-key, site.path.map, feature.hero-section.enable, feature.global-search.events-endpoint,
-      feature.search-widget.enabled, feature.global-search.dms-based]
+      feature.global-search.dms-based, feature.search-widget.enable]
     resourcebundle:messages: ['https://community.visitscotland.com/', discussions/tagged/,
       'localhost,www.visitscotland.com,beta.visitscotland.com,blog.visitscotland.com',
       www.visitscotland.com, 'en,fr,de,nl,it,es', 'true', GTM-WQVX2V, '&gtm_auth=YWMt6gew5Au1PAnzyzMADQ&gtm_preview=env-3&gtm_cookies_win=x',
@@ -189,21 +189,21 @@
       'https://static.visitscotland.com/forms/common/messaging.json', 830-QYE-256,
       //830-QYE-256.mktoweb.com, 6LfqqfcZAAAAACbkbPaHRZTIFpKZGAPZBDkwBKhe, //e.visitscotland.com/js/forms2/js/forms2.min.js,
       //e.visitscotland.com/js/forms2/js/forms2.min.js, pdf, '8', 'true', general/navigation/banner/content,
-      '', '', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
+      '', '14069', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
       vs, AIzaSyCXi9IXsi1Xq3knkQGSgDCcczu9bkHr9-E, /test/examples/map-examples, 'true',
       'https://api.visitscotland.com/dev/data/products/events/search', 'false', 'false']
     resourcebundle:messages_de: ['', '', '', '', '', '', '', '', '', /de-de/site-search-results,
       '12812', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '14974', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_es: ['', '', '', '', '', '', '', '', '', /es-es/site-search-results,
       '12814', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '14975', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_fr: ['', '', '', '', '', '', '', '', '', /fr-fr/site-search-results,
       '12811', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '14973', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_it: ['', '', '', '', '', '', '', '', '', /it-it/site-search-results,
       '12813', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '14976', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_nl: ['', '', '', '', '', '', '', '', '', /nl-nl/site-search-results,
       '12810', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '14972', '', '', '', '', '', '', '', '', '', '', '', '', '']

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/default-site-properties.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/default-site-properties.yaml
@@ -14,7 +14,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2026-01-05T10:27:19.083Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T12:05:16.981Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed
@@ -31,8 +31,12 @@
         \ //830-QYE-256.mktoweb.com", Public Recaptcha Key for Forms, '', Marketo
         Script required for the form to work, '', '', '', '', This property is used
         to set up the Cludo Chatbox functionality, This property is used to set up
-        the Cludo Chatbox functionality, This property is used to set up the Cludo
-        Chatbox functionality, '', '', '', '', '', '', '', '', '', '', '', '']
+        the Cludo Chatbox functionality and for the Site Search Results, This property
+        is used to set up the Cludo Chatbox functionality, Show or hide the Product
+        Search widget for the entire site, '', '', '', '', '', '', '', '', Endpoint
+        for the Events service., This property switches between the DMS‑based search
+        and the Google‑based search., Show or hide the Product Search widget for the
+        homepage]
     resourcebundle:id: default.site.config
     resourcebundle:keys: [iknow-community.url, iknow-community.tagged-discussion,
       links.internal-sites, links.convert-to-relative, seo.alternate-link-locale-order,
@@ -54,24 +58,24 @@
       'https://static.visitscotland.com/forms/common/messaging.json', 830-QYE-256,
       //830-QYE-256.mktoweb.com, 6LfqqfcZAAAAACbkbPaHRZTIFpKZGAPZBDkwBKhe, //e.visitscotland.com/js/forms2/js/forms2.min.js,
       //e.visitscotland.com/js/forms2/js/forms2.min.js, pdf, '8', 'true', general/navigation/banner/content,
-      '', '14069', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
+      '', '12809', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
       vs, AIzaSyCXi9IXsi1Xq3knkQGSgDCcczu9bkHr9-E, /test/examples/map-examples, 'true',
-      'https://api.visitscotland.com/dev/data/products/events/search', 'false', 'false']
+      'https://api.visitscotland.com/dev/data/products/events/search', 'true', 'false']
     resourcebundle:messages_de: ['', '', '', '', '', '', '', '', '', /de-de/site-search-results,
       '12812', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14974', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12812', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_es: ['', '', '', '', '', '', '', '', '', /es-es/site-search-results,
       '12814', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14975', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12814', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_fr: ['', '', '', '', '', '', '', '', '', /fr-fr/site-search-results,
       '12811', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14973', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12811', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_it: ['', '', '', '', '', '', '', '', '', /it-it/site-search-results,
       '12813', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14976', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12813', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_nl: ['', '', '', '', '', '', '', '', '', /nl-nl/site-search-results,
       '12810', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14972', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12810', '', '', '', '', '', '', '', '', '', '', '', '', '']
   /default-site-properties[2]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -81,7 +85,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2026-01-05T10:21:41.686Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T12:00:54.006Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed
@@ -98,8 +102,12 @@
         \ //830-QYE-256.mktoweb.com", Public Recaptcha Key for Forms, '', Marketo
         Script required for the form to work, '', '', '', '', This property is used
         to set up the Cludo Chatbox functionality, This property is used to set up
-        the Cludo Chatbox functionality, This property is used to set up the Cludo
-        Chatbox functionality, '', '', '', '', '', '', '', '', '', '', '', '']
+        the Cludo Chatbox functionality and for the Site Search Results, This property
+        is used to set up the Cludo Chatbox functionality, Show or hide the Product
+        Search widget for the entire site, '', '', '', '', '', '', '', '', Endpoint
+        for the Events service., This property switches between the DMS‑based search
+        and the Google‑based search., Show or hide the Product Search widget for the
+        homepage]
     resourcebundle:id: default.site.config
     resourcebundle:keys: [iknow-community.url, iknow-community.tagged-discussion,
       links.internal-sites, links.convert-to-relative, seo.alternate-link-locale-order,
@@ -121,24 +129,24 @@
       'https://static.visitscotland.com/forms/common/messaging.json', 830-QYE-256,
       //830-QYE-256.mktoweb.com, 6LfqqfcZAAAAACbkbPaHRZTIFpKZGAPZBDkwBKhe, //e.visitscotland.com/js/forms2/js/forms2.min.js,
       //e.visitscotland.com/js/forms2/js/forms2.min.js, pdf, '8', 'true', general/navigation/banner/content,
-      '', '14069', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
+      '', '12809', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
       vs, AIzaSyCXi9IXsi1Xq3knkQGSgDCcczu9bkHr9-E, /test/examples/map-examples, 'true',
-      'https://api.visitscotland.com/dev/data/products/events/search', 'false', 'false']
+      'https://api.visitscotland.com/dev/data/products/events/search', 'true', 'false']
     resourcebundle:messages_de: ['', '', '', '', '', '', '', '', '', /de-de/site-search-results,
       '12812', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14974', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12812', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_es: ['', '', '', '', '', '', '', '', '', /es-es/site-search-results,
       '12814', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14975', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12814', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_fr: ['', '', '', '', '', '', '', '', '', /fr-fr/site-search-results,
       '12811', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14973', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12811', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_it: ['', '', '', '', '', '', '', '', '', /it-it/site-search-results,
       '12813', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14976', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12813', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_nl: ['', '', '', '', '', '', '', '', '', /nl-nl/site-search-results,
       '12810', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14972', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12810', '', '', '', '', '', '', '', '', '', '', '', '', '']
   /default-site-properties[3]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -148,9 +156,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2026-01-05T10:27:19.083Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T12:05:16.981Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2026-01-05T10:27:22.788Z
+    hippostdpubwf:publicationDate: 2026-01-07T12:05:22.371Z
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed
         into Relative URLs when the value of attribute 'links.use-relative-urls is
@@ -166,8 +174,12 @@
         \ //830-QYE-256.mktoweb.com", Public Recaptcha Key for Forms, '', Marketo
         Script required for the form to work, '', '', '', '', This property is used
         to set up the Cludo Chatbox functionality, This property is used to set up
-        the Cludo Chatbox functionality, This property is used to set up the Cludo
-        Chatbox functionality, '', '', '', '', '', '', '', '', '', '', '', '']
+        the Cludo Chatbox functionality and for the Site Search Results, This property
+        is used to set up the Cludo Chatbox functionality, Show or hide the Product
+        Search widget for the entire site, '', '', '', '', '', '', '', '', Endpoint
+        for the Events service., This property switches between the DMS‑based search
+        and the Google‑based search., Show or hide the Product Search widget for the
+        homepage]
     resourcebundle:id: default.site.config
     resourcebundle:keys: [iknow-community.url, iknow-community.tagged-discussion,
       links.internal-sites, links.convert-to-relative, seo.alternate-link-locale-order,
@@ -189,21 +201,21 @@
       'https://static.visitscotland.com/forms/common/messaging.json', 830-QYE-256,
       //830-QYE-256.mktoweb.com, 6LfqqfcZAAAAACbkbPaHRZTIFpKZGAPZBDkwBKhe, //e.visitscotland.com/js/forms2/js/forms2.min.js,
       //e.visitscotland.com/js/forms2/js/forms2.min.js, pdf, '8', 'true', general/navigation/banner/content,
-      '', '14069', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
+      '', '12809', '', 'true', 'true', 'true', Consent, /test/examples/icentres/content,
       vs, AIzaSyCXi9IXsi1Xq3knkQGSgDCcczu9bkHr9-E, /test/examples/map-examples, 'true',
-      'https://api.visitscotland.com/dev/data/products/events/search', 'false', 'false']
+      'https://api.visitscotland.com/dev/data/products/events/search', 'true', 'false']
     resourcebundle:messages_de: ['', '', '', '', '', '', '', '', '', /de-de/site-search-results,
       '12812', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14974', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12812', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_es: ['', '', '', '', '', '', '', '', '', /es-es/site-search-results,
       '12814', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14975', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12814', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_fr: ['', '', '', '', '', '', '', '', '', /fr-fr/site-search-results,
       '12811', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14973', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12811', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_it: ['', '', '', '', '', '', '', '', '', /it-it/site-search-results,
       '12813', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14976', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12813', '', '', '', '', '', '', '', '', '', '', '', '', '']
     resourcebundle:messages_nl: ['', '', '', '', '', '', '', '', '', /nl-nl/site-search-results,
       '12810', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '14972', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '12810', '', '', '', '', '', '', '', '', '', '', '', '', '']

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local-environment.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local-environment.yaml
@@ -10,9 +10,9 @@
     jcr:mixinTypes: ['mix:referenceable']
     jcr:uuid: cafcb863-9c1f-4d5f-81d9-c652dc023fcd
     hippo:availability: []
-    hippostd:holder: admin
     hippostd:retainable: false
     hippostd:state: draft
+    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
     hippostdpubwf:lastModificationDate: 2025-10-06T15:21:18.557+01:00

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local-feature---visitscotland.com.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local-feature---visitscotland.com.yaml
@@ -149,9 +149,10 @@
     hippo:availability: []
     hippostd:retainable: false
     hippostd:state: draft
+    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2025-12-18T15:08:49.307Z
+    hippostdpubwf:lastModificationDate: 2026-01-05T10:21:26.689Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local-feature---visitscotland.com.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local-feature---visitscotland.com.yaml
@@ -149,10 +149,9 @@
     hippo:availability: []
     hippostd:retainable: false
     hippostd:state: draft
-    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-05T15:37:26.056Z
-    hippostdpubwf:lastModificationDate: 2026-01-05T10:21:26.689Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T11:58:28.797Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', List of Hosts that will be marked as internal
         URLs, URLs from this environment will be treated as internal and will be transformed

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/global/search-content-categories.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/global/search-content-categories.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 0a8bb8f5-c92d-4c7e-a550-c3d5d04089cf
   hippo:name: Search content categories
-  hippo:versionHistory: a3cee003-7ce3-433d-a45a-e144ba77c4b2
+  hippo:versionHistory: 2a50c256-9c71-428b-8288-a6894527b9a5
   /search-content-categories[1]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -13,15 +13,15 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-10-17T13:28:50.411+01:00
-    hippostdpubwf:lastModificationDate: 2025-10-31T11:37:06.837Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T11:47:37.057Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', '', '', '', '', '', '']
     resourcebundle:id: content.categories
     resourcebundle:keys: [article, destination, itinerary, event, tours, accommodation,
       travel, about]
-    resourcebundle:messages: [ArticleTest, Destination, Itinerary, Event, Tour, Accommodation,
+    resourcebundle:messages: [Article, Destination, Itinerary, Event, Tour, Accommodation,
       Travel, About us]
-    resourcebundle:messages_de: [ArtikelTest, Reiseziel, Reisevorschlag, Veranstaltung,
+    resourcebundle:messages_de: [Artikel, Reiseziel, Reisevorschlag, Veranstaltung,
       Tour, Unterkunft, Reisen, Über uns]
     resourcebundle:messages_es: [Artículo, Destino, Itinerario, Evento, Excursión,
       Alojamiento, Viajes, Sobre nosotros]
@@ -40,15 +40,15 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-10-17T13:28:50.411+01:00
-    hippostdpubwf:lastModificationDate: 2025-10-31T11:37:22.434Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T11:47:56.351Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', '', '', '', '', '', '']
     resourcebundle:id: content.categories
     resourcebundle:keys: [article, destination, itinerary, event, tours, accommodation,
       travel, about]
-    resourcebundle:messages: [ArticleTest, Destination, Itinerary, Event, Tour, Accommodation,
+    resourcebundle:messages: [Article, Destination, Itinerary, Event, Tour, Accommodation,
       Travel, About us]
-    resourcebundle:messages_de: [ArtikelTest, Reiseziel, Reisevorschlag, Veranstaltung,
+    resourcebundle:messages_de: [Artikel, Reiseziel, Reisevorschlag, Veranstaltung,
       Tour, Unterkunft, Reisen, Über uns]
     resourcebundle:messages_es: [Artículo, Destino, Itinerario, Evento, Excursión,
       Alojamiento, Viajes, Sobre nosotros]
@@ -67,16 +67,16 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-10-17T13:28:50.411+01:00
-    hippostdpubwf:lastModificationDate: 2025-10-31T11:37:22.434Z
+    hippostdpubwf:lastModificationDate: 2026-01-07T11:47:56.351Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2025-10-31T11:37:24.393Z
+    hippostdpubwf:publicationDate: 2026-01-07T11:47:58.912Z
     resourcebundle:descriptions: ['', '', '', '', '', '', '', '']
     resourcebundle:id: content.categories
     resourcebundle:keys: [article, destination, itinerary, event, tours, accommodation,
       travel, about]
-    resourcebundle:messages: [ArticleTest, Destination, Itinerary, Event, Tour, Accommodation,
+    resourcebundle:messages: [Article, Destination, Itinerary, Event, Tour, Accommodation,
       Travel, About us]
-    resourcebundle:messages_de: [ArtikelTest, Reiseziel, Reisevorschlag, Veranstaltung,
+    resourcebundle:messages_de: [Artikel, Reiseziel, Reisevorschlag, Veranstaltung,
       Tour, Unterkunft, Reisen, Über uns]
     resourcebundle:messages_es: [Artículo, Destino, Itinerario, Evento, Excursión,
       Alojamiento, Viajes, Sobre nosotros]

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/options/content-categories.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/options/content-categories.yaml
@@ -12,65 +12,313 @@
     hippotranslation:locale: inherited - from query
     /selection:listitem[1]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/attractions/arts-culture
-      selection:label: culture-history
+      selection:key: /places-to-go/aberdeen/
+      selection:label: city-break
     /selection:listitem[2]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/events
-      selection:label: events
+      selection:key: /places-to-go/city-breaks/
+      selection:label: city-break
     /selection:listitem[3]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/family
-      selection:label: family-friendly
+      selection:key: /places-to-go/edinburgh/
+      selection:label: city-break
     /selection:listitem[4]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/passes-offers
-      selection:label: family-friendly
+      selection:key: /places-to-go/dundee/
+      selection:label: city-break
     /selection:listitem[5]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/food-drink
-      selection:label: food-drink
+      selection:key: /places-to-go/dunfermline/
+      selection:label: city-break
     /selection:listitem[6]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/outdoor-activities
-      selection:label: active-adventure
+      selection:key: /places-to-go/glasgow/
+      selection:label: city-break
     /selection:listitem[7]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/landscapes-nature
-      selection:label: nature-outdoors
+      selection:key: /places-to-go/inverness/
+      selection:label: city-break
     /selection:listitem[8]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/iconic-spots-alternatives
-      selection:label: nature-outdoors
+      selection:key: /places-to-go/perth/
+      selection:label: city-break
     /selection:listitem[9]:
+      jcr:primaryType: selection:listitem
+      selection:key: /places-to-go/stirling/
+      selection:label: city-break
+    /selection:listitem[10]:
+      jcr:primaryType: selection:listitem
+      selection:key: /places-to-go/countryside-breaks
+      selection:label: nature-outdoors
+    /selection:listitem[11]:
+      jcr:primaryType: selection:listitem
+      selection:key: /places-to-go/islands
+      selection:label: nature-outdoors
+    /selection:listitem[12]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/hidden-gems/
+      selection:label: culture-history
+    /selection:listitem[13]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/gardens-parks
+      selection:label: nature-outdoors
+    /selection:listitem[14]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/witch-trail
+      selection:label: culture-history
+    /selection:listitem[15]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/rainy-day
+      selection:label: travel-information
+    /selection:listitem[16]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/most-visited
+      selection:label: travel-information
+    /selection:listitem[17]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/dundee
+      selection:label: city-break
+    /selection:listitem[18]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/museums-galleries
+      selection:label: culture-history
+    /selection:listitem[19]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/haunted-sites
+      selection:label: culture-history
+    /selection:listitem[20]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/glasgow
+      selection:label: city-break
+    /selection:listitem[21]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/aberdeen
+      selection:label: city-break
+    /selection:listitem[22]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/architecture
+      selection:label: culture-history
+    /selection:listitem[23]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/arts-culture
+      selection:label: culture-history
+    /selection:listitem[24]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/creepy-abandoned-places
+      selection:label: nature-outdoors
+    /selection:listitem[25]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/castles
+      selection:label: culture-history
+    /selection:listitem[26]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/aberdeen
+      selection:label: city-break
+    /selection:listitem[27]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/highlands
+      selection:label: nature-outdoors
+    /selection:listitem[28]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/unesco
+      selection:label: nature-outdoors
+    /selection:listitem[29]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/free/
+      selection:label: travel-information
+    /selection:listitem[30]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/historic
+      selection:label: culture-history
+    /selection:listitem[31]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/magical-landmarks
+      selection:label: nature-outdoors
+    /selection:listitem[32]:
+      jcr:primaryType: selection:listitem
+      selection:key: /attractions/tv-film
+      selection:label: culture-history
+    /selection:listitem[33]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/unesco-trail/dundee-city-of-design
+      selection:label: city-break
+    /selection:listitem[34]:
       jcr:primaryType: selection:listitem
       selection:key: /things-to-do/inspiring-spots
       selection:label: nature-outdoors
-    /selection:listitem[10]:
+    /selection:listitem[35]:
       jcr:primaryType: selection:listitem
-      selection:key: /things-to-do/tours
-      selection:label: tours
-    /selection:listitem[11]:
+      selection:key: /things-to-do/unesco-trail/glasgow-city-of-music
+      selection:label: city-break
+    /selection:listitem[36]:
       jcr:primaryType: selection:listitem
-      selection:key: /travel-planning/touring
-      selection:label: tours
-    /selection:listitem[12]:
+      selection:key: /things-to-do/unesco-trail/edinburgh-city-of-literature
+      selection:label: city-break
+    /selection:listitem[37]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/iconic-spots-alternatives
+      selection:label: active-adventure
+    /selection:listitem[38]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/unesco-trail/edinburgh-old-new-towns
+      selection:label: city-break
+    /selection:listitem[39]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/family
+      selection:label: family-friendly
+    /selection:listitem[40]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/food-drink
+      selection:label: food-drink
+    /selection:listitem[41]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/unesco-trail/perth-city-of-craft
+      selection:label: city-break
+    /selection:listitem[42]:
       jcr:primaryType: selection:listitem
       selection:key: /things-to-do/unesco-trail
       selection:label: nature-outdoors
-    /selection:listitem[13]:
+    /selection:listitem[43]:
       jcr:primaryType: selection:listitem
-      selection:key: /info/tours
+      selection:key: /things-to-do/iconic-spots-alternatives
+      selection:label: nature-outdoors
+    /selection:listitem[44]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/landscapes-nature
+      selection:label: nature-outdoors
+    /selection:listitem[45]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/outdoor-activities
+      selection:label: active-adventure
+    /selection:listitem[46]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/research-your-ancestry
+      selection:label: culture-history
+    /selection:listitem[47]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/tours
       selection:label: tours
-    /selection:listitem[14]:
+    /selection:listitem[48]:
       jcr:primaryType: selection:listitem
-      selection:key: /places-to-go
-      selection:label: city-break
-    /selection:listitem[15]:
+      selection:key: /things-to-do/passes-offers
+      selection:label: family-friendly
+    /selection:listitem[49]:
       jcr:primaryType: selection:listitem
-      selection:key: /accommodation
-      selection:label: accommodation
-    /selection:listitem[16]:
+      selection:key: /things-to-do/wellness
+      selection:label: wellness
+    /selection:listitem[50]:
+      jcr:primaryType: selection:listitem
+      selection:key: /travel-planning/touring
+      selection:label: tours
+    /selection:listitem[51]:
       jcr:primaryType: selection:listitem
       selection:key: /travel-planning
       selection:label: travel-information
+    /selection:listitem[52]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/large-groups
+      selection:label: accommodation
+    /selection:listitem[53]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/magical-places-to-stay
+      selection:label: family-friendly
+    /selection:listitem[54]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/must-visit-destinations
+      selection:label: travel-information
+    /selection:listitem[55]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/outdoor-saunas
+      selection:label: wellness
+    /selection:listitem[56]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/speyside-malt-whisky-trail-itinerary
+      selection:label: food-drink
+    /selection:listitem[57]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/stirling-places-to-eat
+      selection:label: food-drink
+    /selection:listitem[58]:
+      jcr:primaryType: selection:listitem
+      selection:key: /blog/
+      selection:label: active-adventure
+    /selection:listitem[59]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/calendar
+      selection:label: travel-information
+    /selection:listitem[60]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/christmas-winter-festivals/edinburgh
+      selection:label: city-break
+    /selection:listitem[61]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/christmas-winter-festivals/aberdeen
+      selection:label: city-break
+    /selection:listitem[62]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/christmas-winter-festivals/inverness
+      selection:label: city-break
+    /selection:listitem[63]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/christmas-winter-festivals/perth
+      selection:label: city-break
+    /selection:listitem[64]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/edinburgh-festivals
+      selection:label: city-break
+    /selection:listitem[65]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/food-festivals/
+      selection:label: food-drink
+    /selection:listitem[66]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/seasonal
+      selection:label: travel-information
+    /selection:listitem[67]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/sound-light-shows
+      selection:label: nature-outdoors
+    /selection:listitem[68]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/submit-event
+      selection:label: about
+    /selection:listitem[69]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/winter-events
+      selection:label: travel-information
+    /selection:listitem[70]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do/events/
+      selection:label: culture-history
+    /selection:listitem[71]:
+      jcr:primaryType: selection:listitem
+      selection:key: /about
+      selection:label: about
+    /selection:listitem[72]:
+      jcr:primaryType: selection:listitem
+      selection:key: /contact-us
+      selection:label: about
+    /selection:listitem[73]:
+      jcr:primaryType: selection:listitem
+      selection:key: /newsletter
+      selection:label: about
+    /selection:listitem[74]:
+      jcr:primaryType: selection:listitem
+      selection:key: /policies
+      selection:label: about
+    /selection:listitem[75]:
+      jcr:primaryType: selection:listitem
+      selection:key: /accommodation
+      selection:label: accommodation
+    /selection:listitem[76]:
+      jcr:primaryType: selection:listitem
+      selection:key: /places-to-go
+      selection:label: nature-outdoors
+    /selection:listitem[77]:
+      jcr:primaryType: selection:listitem
+      selection:key: /things-to-do
+      selection:label: travel-information
+    /selection:listitem[78]:
+      jcr:primaryType: selection:listitem
+      selection:key: /info/tours
+      selection:label: tours

--- a/site/components/src/main/java/com/visitscotland/brxm/components/breadcrumb/VsBreadcrumbComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/breadcrumb/VsBreadcrumbComponent.java
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
-import javax.swing.text.StringContent;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,20 +26,27 @@ public class VsBreadcrumbComponent extends CommonComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(VsBreadcrumbComponent.class.getName());
 
-    final String REQUESTED_URI = "requestedURI";
-    final String IS_HOME = "isHome";
-    final String BREADCRUMB = "breadcrumb";
-    final String DOCUMENT = "document";
-    final String ORDERED_TRANSLATIONS = "orderedTranslations";
-    final String CONTENT_CATEGORIES_OPTIONS = "content-categories-options";
-    final String CONTENT_TYPE_OPTIONS = "content-content-type";
-    final String SEARCH_CATEGORY = "searchCategory";
-    final String SEARCH_CONTENT_TYPE = "searchContentType";
-    final String OTHER_VALUE = "other";
+    private static final String REQUESTED_URI = "requestedURI";
+    private static final String IS_HOME = "isHome";
+    private static final String BREADCRUMB = "breadcrumb";
+    private static final String DOCUMENT = "document";
+    private static final String ORDERED_TRANSLATIONS = "orderedTranslations";
+    private static final String CONTENT_CATEGORIES_OPTIONS = "content-categories-options";
+    private static final String CONTENT_TYPE_OPTIONS = "content-content-type";
+    private static final String SEARCH_CATEGORY = "searchCategory";
+    private static final String SEARCH_CONTENT_TYPE = "searchContentType";
+    private static final String OTHER = "other";
 
     private VsBreadCrumbProvider breadcrumbProvider;
     private HippoUtilsService hippoUtilsService;
     private DocumentUtilsService documentUtils;
+
+    public void init(ServletContext servletContext, ComponentConfiguration componentConfig) throws HstComponentException {
+        super.init(servletContext, componentConfig);
+        this.breadcrumbProvider = new VsBreadCrumbProvider(this);
+        this.hippoUtilsService = VsComponentManager.get(HippoUtilsService.class);
+        this.documentUtils = VsComponentManager.get(DocumentUtilsService.class);
+    }
 
     public void doBeforeRender(HstRequest request, HstResponse response) throws HstComponentException {
         super.doBeforeRender(request, response);
@@ -52,7 +58,7 @@ public class VsBreadcrumbComponent extends CommonComponent {
         //Breadcrumb Items list
         request.setModel(BREADCRUMB, this.breadcrumbProvider.getBreadcrumb(request));
         //Search category for Cludo site search
-        request.setModel(SEARCH_CATEGORY, getValueFromValueListAndUrl(request, CONTENT_CATEGORIES_OPTIONS));
+        request.setModel(SEARCH_CATEGORY, getValueFromValueListAndUrl(request, CONTENT_CATEGORIES_OPTIONS).orElse(OTHER));
         //Main document for the page
         setDocument(request, response);
     }
@@ -64,41 +70,52 @@ public class VsBreadcrumbComponent extends CommonComponent {
             // Translations ordered by SEO order
             List<BaseDocument> availableTranslations = ((Page) document.get()).getAvailableTranslations(BaseDocument.class).getTranslations();
             request.setModel(ORDERED_TRANSLATIONS, documentUtils.sortTranslationsForSeo(availableTranslations));
-            String contentType = getValueFromValueListAndUrl(request, CONTENT_TYPE_OPTIONS);
-            if (contentType.equals(OTHER_VALUE)){
-                if (document.get() instanceof Destination) {
-                    contentType = "destination";
-                } else if (document.get() instanceof Itinerary){
-                    contentType = "itinerary";
-                } else {
-                    contentType = "article";
-                }
-            }
-            //Search contentType for Cludo site search
-            request.setModel(SEARCH_CONTENT_TYPE, contentType);
+
+            request.setModel(SEARCH_CONTENT_TYPE, getContentType(request, document.get()));
         } else {
             logger.debug("{} page not found - redirecting to 404 page", request.getRequestURI());
             this.pageNotFound(response);
         }
     }
 
-    public void init(ServletContext servletContext, ComponentConfiguration componentConfig) throws HstComponentException {
-        super.init(servletContext, componentConfig);
-        this.breadcrumbProvider = new VsBreadCrumbProvider(this);
-        this.hippoUtilsService = VsComponentManager.get(HippoUtilsService.class);
-        this.documentUtils = VsComponentManager.get(DocumentUtilsService.class);
+    /**
+     * Determines the content type for the Cludo search categorization based on the request URL and document type.
+     * <p>
+     * This method follows a hierarchical approach to determine the content type:
+     * <ol>
+     *   <li>First checks if a specific content type is configured in the value list that matches the URL path</li>
+     *   <li>If no URL-based match is found, determines type based on the document's class type</li>
+     *   <li>Falls back to "article" as the default content type</li>
+     * </ol>
+     *
+     * @param request the HST request containing the URL path information
+     * @param document the Hippo document bean to analyze for type determination
+     *
+     * @return the content type string used for search categorization.
+     */
+    private String getContentType(HstRequest request, HippoBean document) {
+        Optional<String> type = getValueFromValueListAndUrl(request, CONTENT_TYPE_OPTIONS);
+        if (type.isPresent()){
+            return type.get();
+        } else if (document instanceof Destination) {
+            return "destination";
+        } else if (document instanceof Itinerary){
+            return "itinerary";
+        } else {
+            return "article";
+        }
     }
 
     /**
      * Returns the category that best matches the given URL.
      */
-    private String getValueFromValueListAndUrl(HstRequest request, String valueListPath) {
+    private Optional<String> getValueFromValueListAndUrl(HstRequest request, String valueListPath) {
         for (Map.Entry<String, String> entry : hippoUtilsService.getValueMap(valueListPath).entrySet()) {
             if (request.getPathInfo().contains(entry.getKey())) {
-                return entry.getValue();
+                return Optional.of(entry.getValue());
             }
         }
-        return OTHER_VALUE;
+        return Optional.empty();
     }
 
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/DestinationContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/DestinationContentComponent.java
@@ -5,6 +5,7 @@ import com.visitscotland.brxm.dms.LocationLoader;
 import com.visitscotland.brxm.dms.model.LocationObject;
 import com.visitscotland.brxm.hippobeans.Destination;
 import com.visitscotland.brxm.pagebuilder.PageAssembler;
+import com.visitscotland.brxm.pagebuilder.PageCompositionHelper;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.slf4j.Logger;
@@ -27,18 +28,20 @@ public class DestinationContentComponent extends PageContentComponent<Destinatio
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
-        super.doBeforeRender(request, response);
+        PageCompositionHelper pageConfig = new PageCompositionHelper(getBundle(), request);
 
-        addAttributesToRequest(request);
+        super.doBeforeRender(request, response, pageConfig);
+
+        addAttributesToRequest(request, pageConfig);
     }
 
-    void addAttributesToRequest(HstRequest request) {
+    void addAttributesToRequest(HstRequest request, PageCompositionHelper pageConfig) {
         Destination document = (Destination) request.getAttribute("document");
         LocationObject location = locationLoader.getLocation(document.getLocation(), Locale.UK);
         request.setModel("location", location);
         request.setModel("region", locationLoader.getRegion(location, Locale.UK));
 
-        builder.addModules(request);
+        builder.addModules(request , pageConfig);
     }
 
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralBSHContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralBSHContentComponent.java
@@ -6,6 +6,7 @@ import com.visitscotland.brxm.hippobeans.GeneralBSH;
 import com.visitscotland.brxm.model.FlatBlog;
 import com.visitscotland.brxm.model.megalinks.HorizontalListLinksModule;
 import com.visitscotland.brxm.pagebuilder.PageAssembler;
+import com.visitscotland.brxm.pagebuilder.PageCompositionHelper;
 import com.visitscotland.utils.Contract;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
@@ -31,12 +32,14 @@ public class GeneralBSHContentComponent extends PageContentComponent<GeneralBSH>
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
-        super.doBeforeRender(request, response);
+        PageCompositionHelper pageConfig = new PageCompositionHelper(getBundle(), request);
+
+        super.doBeforeRender(request, response, pageConfig);
 
         addReadData(request);
         addPageStatusCode(request, response);
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(getBundle(), request));
     }
 
     @Override

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralBSHContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralBSHContentComponent.java
@@ -39,7 +39,7 @@ public class GeneralBSHContentComponent extends PageContentComponent<GeneralBSH>
         addReadData(request);
         addPageStatusCode(request, response);
 
-        builder.addModules(request, new PageCompositionHelper(getBundle(), request));
+        builder.addModules(request, pageConfig);
     }
 
     @Override

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralContentComponent.java
@@ -45,7 +45,7 @@ public class GeneralContentComponent extends PageContentComponent<General> {
             request.setModel(ERROR_CODE, pageStatus);
         }
         addNavigationCards(request);
-        builder.addModules(request, new PageCompositionHelper(getBundle(), request));
+        builder.addModules(request, pageConfig);
     }
 
     private void addNavigationCards(HstRequest request){

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/GeneralContentComponent.java
@@ -5,6 +5,7 @@ import com.visitscotland.brxm.config.VsComponentManager;
 import com.visitscotland.brxm.hippobeans.General;
 import com.visitscotland.brxm.pagebuilder.PageAssembler;
 import com.visitscotland.brxm.pagebuilder.PageCompositionException;
+import com.visitscotland.brxm.pagebuilder.PageCompositionHelper;
 import com.visitscotland.brxm.pagebuilder.page.PageIntroAssembler;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
@@ -34,7 +35,9 @@ public class GeneralContentComponent extends PageContentComponent<General> {
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
-        super.doBeforeRender(request, response);
+        PageCompositionHelper pageConfig = new PageCompositionHelper(getBundle(), request);
+
+        super.doBeforeRender(request, response, pageConfig);
         GeneralPageComponentInfo pageInfo = getComponentParametersInfo(request);
         int pageStatus = Integer.parseInt(pageInfo.getStatus());
         response.setStatus(pageStatus);
@@ -42,7 +45,7 @@ public class GeneralContentComponent extends PageContentComponent<General> {
             request.setModel(ERROR_CODE, pageStatus);
         }
         addNavigationCards(request);
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(getBundle(), request));
     }
 
     private void addNavigationCards(HstRequest request){

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/ItineraryContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/ItineraryContentComponent.java
@@ -6,6 +6,7 @@ import com.visitscotland.brxm.dms.ProductSearchBuilder;
 import com.visitscotland.brxm.factory.ItineraryFactory;
 import com.visitscotland.brxm.hippobeans.Itinerary;
 import com.visitscotland.brxm.model.ItineraryPage;
+import com.visitscotland.brxm.pagebuilder.PageCompositionHelper;
 import com.visitscotland.utils.Contract;
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.template.TemplateHashModel;
@@ -32,7 +33,9 @@ public class ItineraryContentComponent extends PageContentComponent<Itinerary> {
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
-        super.doBeforeRender(request, response);
+        PageCompositionHelper pageConfig = new PageCompositionHelper(getBundle(), request);
+
+        super.doBeforeRender(request, response, pageConfig);
 
         addProductSearchBuilder(request);
         includeLabels(request);

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/ListicleContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/ListicleContentComponent.java
@@ -3,6 +3,7 @@ package com.visitscotland.brxm.components.content;
 import com.visitscotland.brxm.config.VsComponentManager;
 import com.visitscotland.brxm.factory.ListicleFactory;
 import com.visitscotland.brxm.hippobeans.Listicle;
+import com.visitscotland.brxm.pagebuilder.PageCompositionHelper;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.slf4j.Logger;
@@ -29,7 +30,9 @@ public class ListicleContentComponent extends PageContentComponent<Listicle> {
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
-        super.doBeforeRender(request, response);
+        PageCompositionHelper pageConfig = new PageCompositionHelper(getBundle(), request);
+
+        super.doBeforeRender(request, response, pageConfig);
 
         addLabels(request);
 

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
@@ -34,6 +34,10 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(PageContentComponent.class);
 
+    //refId of sitemap items
+    public static final String ROOT = "root";
+    public static final String SEARCH_PAGE = "search-page";
+
     /* Should we use Content Logger instead of Freemarker?
      *
      * TODO: Verify usage of this logger and decide what to do with this
@@ -190,7 +194,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     }
 
     private boolean isHomepage (HstRequest request){
-        return "root".equals(request.getRequestContext().getResolvedSiteMapItem().getHstSiteMapItem().getId());
+        return ROOT.equals(request.getRequestContext().getResolvedSiteMapItem().getHstSiteMapItem().getId());
     }
 
     /**
@@ -483,9 +487,8 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     private Optional<String> getSearchResultsURL(final HstRequest request) {
         HstRequestContext requestContext = request.getRequestContext();
 
-        // Create a link to the sitemap item with refId "search-page"
         HstLink link = requestContext.getHstLinkCreator()
-                .createByRefId("search-page", requestContext.getResolvedMount().getMount());
+                .createByRefId(SEARCH_PAGE, requestContext.getResolvedMount().getMount());
 
         if (link != null) {
             // Convert the link to a URL and make it available to the template

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
@@ -105,12 +105,17 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
         properties = VsComponentManager.get(SiteProperties.class);
         bundle = VsComponentManager.get(ResourceBundleService.class);
         metadata = VsComponentManager.get(MetadataFactory.class);
+    }
 
+    ResourceBundleService getBundle() {
+        return bundle;
     }
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
-        throw new IllegalArgumentException();
+        throw new UnsupportedOperationException(
+                "doBeforeRender(HstRequest, HstResponse) is not supported. " +
+                "Use doBeforeRender(HstRequest, HstResponse, PageCompositionHelper) instead.");
     }
 
     public void doBeforeRender(HstRequest request, HstResponse response, PageCompositionHelper pageConfig) {
@@ -128,9 +133,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
         addSiteSpecificConfiguration(request, pageConfig);
     }
 
-    public ResourceBundleService getBundle() {
-        return bundle;
-    }
+
 
     /**
      * Adds Metadata about the application to the request
@@ -418,7 +421,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
                 pageConfig.addProperty("dms-based", "true");
                 setGeneralCludoConfiguration(pageConfig);
             } else {
-                applyGlobalSeachConfiguration(request, pageConfig);
+                applyGlobalSearchConfiguration(request, pageConfig);
             }
         }
     }
@@ -426,7 +429,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
 
     /**
      * Set General Cludo Configuration for the Global Search
-     * @param pageConfig
+     * @param pageConfig the page composition helper to add configuration properties to
      */
     private void setGeneralCludoConfiguration(PageCompositionHelper pageConfig) {
         properties.getGlobalSearchURL().ifPresent(v -> pageConfig.addProperty("global-search-url", v));
@@ -438,10 +441,10 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
 
     /**
      * Apply the site search configuration to the pages where the search component is available
-     * @param request
-     * @param pageConfig
+     * @param request the current HST request
+     * @param pageConfig the page composition helper to add configuration properties to
      */
-    private void applyGlobalSeachConfiguration(HstRequest request, PageCompositionHelper pageConfig) {
+    private void applyGlobalSearchConfiguration(HstRequest request, PageCompositionHelper pageConfig) {
         if (isHomepage(request) ||
                 getSearchResultsURL(request).filter(link -> link.equals(request.getRequestURI())).isPresent()) {
 

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
@@ -59,7 +59,6 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     private static final String SEARCH_EVENTS_CATEGORIES = "content.categories";
     private static final String SEARCH_EVENTS_FILTERS = "search-events-filters";
     private static final String SEARCH_FILTERS = "search-categories";
-    private static final String EVENTS_API = "eventsAPI";
 
     //TODO Duplicate where it is used
     protected static final String OTYML_BUNDLE = "otyml";
@@ -436,10 +435,10 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
      * @param pageConfig the page composition helper to add configuration properties to
      */
     private void setGeneralCludoConfiguration(PageCompositionHelper pageConfig) {
-        properties.getGlobalSearchURL().ifPresent(v -> pageConfig.addProperty("global-search-url", v));
-        properties.getCludoCustomerId().ifPresent(v -> pageConfig.addProperty("customer-id", v));
-        properties.getCludoEngineId().ifPresent(v -> pageConfig.addProperty("engine-id", v));
-        properties.getCludoExperienceId().ifPresent(v -> pageConfig.addProperty("experience-id", v));
+        properties.getGlobalSearchURL().ifPresent(v -> pageConfig.addProperty("global-search.path", v));
+        properties.getCludoCustomerId().ifPresent(v -> pageConfig.addProperty("cludo.customer-id", v));
+        properties.getCludoEngineId().ifPresent(v -> pageConfig.addProperty("cludo.engine-id", v));
+        properties.getCludoExperienceId().ifPresent(v -> pageConfig.addProperty("cludo.experience-id", v));
         pageConfig.addProperty("language", pageConfig.getLocale().getLanguage());
     }
 
@@ -449,22 +448,22 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
      * @param pageConfig the page composition helper to add configuration properties to
      */
     private void applyGlobalSearchConfiguration(HstRequest request, PageCompositionHelper pageConfig) {
-        if (isHomepage(request) ||
-                getSearchResultsURL(request).filter(link -> link.equals(request.getRequestURI())).isPresent()) {
+        boolean searchResultsPage = getSearchResultsURL(request).filter(link -> link.equals(request.getRequestURI())).isPresent();
 
+        if (isHomepage(request) || searchResultsPage) {
             setGeneralCludoConfiguration(pageConfig);
-
-            pageConfig.addAllSiteLabels(SEARCH_FILTERS);
-            pageConfig.addProperty(EVENTS_API, properties.getGlobalSearchEventsEndpoint());
             properties.getGlobalSearchEventsEndpoint().ifPresentOrElse(
                     v -> pageConfig.addProperty("events-endpoint", v),
                     () -> logger.error("The URL for the events Endpoint hasn't been defined"));
 
-            if (isHomepage(request)) {
+            pageConfig.addAllSiteLabels(SEARCH_FILTERS);
+
+            if (searchResultsPage) {
+                pageConfig.addAllSiteLabels(SEARCH_EVENTS_FILTERS);
+                pageConfig.addAllSiteLabels(SEARCH_EVENTS_CATEGORIES);
+            } else {
                 pageConfig.addProperty(INCLUDE_SEARCH_WIDGET, properties.getFeatureSearchWidget());
                 properties.getGlobalSearchURL().ifPresent(url -> pageConfig.addProperty(SEARCH_LINK, url));
-            } else {
-                pageConfig.addAllSiteLabels(SEARCH_EVENTS_FILTERS);
             }
         }
     }

--- a/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/components/content/PageContentComponent.java
@@ -13,6 +13,7 @@ import com.visitscotland.brxm.model.Module;
 import com.visitscotland.brxm.model.SignpostModule;
 import com.visitscotland.brxm.model.megalinks.EnhancedLink;
 import com.visitscotland.brxm.model.megalinks.HorizontalListLinksModule;
+import com.visitscotland.brxm.pagebuilder.PageCompositionHelper;
 import com.visitscotland.brxm.services.LinkService;
 import com.visitscotland.brxm.services.ResourceBundleService;
 import com.visitscotland.brxm.utils.ContentLogger;
@@ -50,6 +51,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     private static final String SEO_BUNDLE = "seo";
     private static final String TABLE_CONTENTS_BUNDLE = "table-contents";
     private static final String MEGALINKS_BUNDLE = "megalinks";
+    //TODO: Review: This constant is not in use
     private static final String SEARCH_EVENTS_CATEGORIES = "content.categories";
     private static final String SEARCH_EVENTS_FILTERS = "search-events-filters";
     private static final String SEARCH_FILTERS = "search-categories";
@@ -61,7 +63,6 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     //Objects injected in the page payload
     public static final String DOCUMENT = "document";
     public static final String EDIT_MODE = "editMode";
-    public static final String SEARCH_LINK = "searchLink";
 
     public static final String AUTHOR = "author";
     public static final String NEWSLETTER_SIGNPOST = "newsletterSignpost";
@@ -75,9 +76,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     public static final String PSR_WIDGET = "psrWidget";
 
     public static final String INCLUDE_SEARCH_WIDGET = "searchWidget";
-    public static final String SEARCH_RESULTS = "searchResultsPage";
-    public static final String SEARCH_RESULTS_URL = "searchResultsUrl";
-    public static final String MAP_PAGE = "mainMapPage";
+    public static final String SEARCH_LINK = "searchLink";
     public static final String METADATA_MODEL = "metadata";
     public static final String GTM = "gtm";
 
@@ -111,6 +110,10 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
+        throw new IllegalArgumentException();
+    }
+
+    public void doBeforeRender(HstRequest request, HstResponse response, PageCompositionHelper pageConfig) {
         super.doBeforeRender(request, response);
 
         addMetadata(request);
@@ -122,7 +125,11 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
         addBlog(request);
         addGtmConfiguration(request);
         addLabels(request);
-        addSiteSpecificConfiguration(request);
+        addSiteSpecificConfiguration(request, pageConfig);
+    }
+
+    public ResourceBundleService getBundle() {
+        return bundle;
     }
 
     /**
@@ -335,9 +342,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
                 signpost = newsletterFactory.createNewsletterSignpostModule(request.getLocale());
             }
 
-            if (signpost.isPresent()) {
-                request.setModel(NEWSLETTER_SIGNPOST, signpost.get());
-            }
+            signpost.ifPresent(signpostModule -> request.setModel(NEWSLETTER_SIGNPOST, signpostModule));
         }
     }
 
@@ -347,7 +352,6 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
     private void addProductSearchWidget(HstRequest request) {
         final String PRODUCT_SEARCH_BUNDLE = "product-search-widget";
 
-        //TODO: We shouldn't use orElse in this case
         if (!request.getPathInfo().contains(properties.getSiteSkiSection())
                 && !request.getPathInfo().contains(properties.getCampaignSection())) {
             request.setModel(PSR_WIDGET, psrFactory.getWidget(request));
@@ -371,6 +375,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
      * @param request HstRequest
      * @return the main document of
      */
+    @SuppressWarnings("unchecked")
     protected T getDocument(HstRequest request) {
         if (request.getAttribute(DOCUMENT) instanceof Page) {
             return (T) request.getAttribute(DOCUMENT);
@@ -398,7 +403,7 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
      * Add Configuration specific to the VisitScotland.com or businessevents site
      * @param request HSt request
      */
-    private void addSiteSpecificConfiguration(HstRequest request) {
+    private void addSiteSpecificConfiguration(HstRequest request, PageCompositionHelper pageConfig) {
         if (properties.isProductSearchEnabled()){
             addProductSearchWidget(request);
         }
@@ -408,53 +413,65 @@ public class PageContentComponent<T extends Page> extends ContentComponent {
         }
 
         if (properties.isGlobalSearchEnabled()){
-            enableGlobalSearch(request);
-            addSearchWidget(request);
+            if (properties.isGlobalSearchDmsBased()) {
+                //TODO: This method will be removed once the DMS is retired
+                pageConfig.addProperty("dms-based", "true");
+                setGeneralCludoConfiguration(pageConfig);
+            } else {
+                applyGlobalSeachConfiguration(request, pageConfig);
+            }
         }
     }
 
+
     /**
-     * Enable Global Search in the site
-     * @param request
+     * Set General Cludo Configuration for the Global Search
+     * @param pageConfig
      */
-    private void enableGlobalSearch(HstRequest request){
-        Map<String, String> searchProperties = new HashMap<>();
-        properties.getGlobalSearchURL().ifPresent(v -> searchProperties.put("global-search-url", v));
-        properties.getCludoCustomerId().ifPresent(v -> searchProperties.put("customer-id", v));
-        properties.getCludoEngineId().ifPresent(v -> searchProperties.put("engine-id", v));
-        properties.getCludoExperienceId().ifPresent(v -> searchProperties.put("experience-id", v));
+    private void setGeneralCludoConfiguration(PageCompositionHelper pageConfig) {
+        properties.getGlobalSearchURL().ifPresent(v -> pageConfig.addProperty("global-search-url", v));
+        properties.getCludoCustomerId().ifPresent(v -> pageConfig.addProperty("customer-id", v));
+        properties.getCludoEngineId().ifPresent(v -> pageConfig.addProperty("engine-id", v));
+        properties.getCludoExperienceId().ifPresent(v -> pageConfig.addProperty("experience-id", v));
+        pageConfig.addProperty("language", pageConfig.getLocale().getLanguage());
+    }
 
-        searchProperties.put("language", request.getLocale().getLanguage());
+    /**
+     * Apply the site search configuration to the pages where the search component is available
+     * @param request
+     * @param pageConfig
+     */
+    private void applyGlobalSeachConfiguration(HstRequest request, PageCompositionHelper pageConfig) {
+        if (isHomepage(request) ||
+                getSearchResultsURL(request).filter(link -> link.equals(request.getRequestURI())).isPresent()) {
 
-        request.setModel("cludo", searchProperties);
+            setGeneralCludoConfiguration(pageConfig);
+
+            pageConfig.addAllSiteLabels(SEARCH_FILTERS);
+            pageConfig.addProperty(EVENTS_API, properties.getGlobalSearchEventsEndpoint());
+            properties.getGlobalSearchEventsEndpoint().ifPresentOrElse(
+                    v -> pageConfig.addProperty("events-endpoint", v),
+                    () -> logger.error("The URL for the events Endpoint hasn't been defined"));
+
+            if (isHomepage(request)) {
+                pageConfig.addProperty(INCLUDE_SEARCH_WIDGET, properties.getFeatureSearchWidget());
+                properties.getGlobalSearchURL().ifPresent(url -> pageConfig.addProperty(SEARCH_LINK, url));
+            } else {
+                pageConfig.addAllSiteLabels(SEARCH_EVENTS_FILTERS);
+            }
+        }
     }
 
     boolean isEditMode(HstRequest request) {
         return Boolean.TRUE.equals(request.getAttribute(EDIT_MODE));
     }
 
-    private void addSearchWidget(HstRequest request) {
-        if (isHomepage(request) ||
-                getSearchResultsURL(request).filter(link -> link.equals(request.getRequestURI())).isPresent()) {
-
-            addAllLabels(request, SEARCH_FILTERS);
-            request.setModel(EVENTS_API, properties.getEventsEndpoint());
-
-            if (isHomepage(request)) {
-                request.setModel(INCLUDE_SEARCH_WIDGET, properties.getFeatureSearchWidget());
-                properties.getGlobalSearchURL().ifPresent(url -> request.setModel(SEARCH_LINK, url));
-            } else {
-                addAllLabels(request, SEARCH_EVENTS_FILTERS);
-            }
-        }
-    }
-
     /**
      * Creates and exposes a locale-aware search page link in the HST request context.
-     *
+     * <br>
      * This method generates an HstLink for the sitemap item with refId "search-page"
-     * and stores it as a request attribute named "searchLink"
-     *
+     * and stores it as a request attribute named "searchLink".
+     * <br>
      * Use this to ensure the search URL is correctly resolved for the current
      * locale and mount, avoiding hardcoded or relative paths in templates
      *

--- a/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageAssembler.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageAssembler.java
@@ -54,7 +54,6 @@ public class PageAssembler {
     private final EventsListingMapper eventsListingMapper;
     private final SpotlightMapper spotlightMapper;
 
-    private final ResourceBundleService bundle;
     private final Logger contentLogger;
 
     @Autowired
@@ -86,7 +85,6 @@ public class PageAssembler {
         this.formMapper = formMapper;
         this.ctaBannerMapper = ctaBannerMapper;
         this.eventsListingMapper = eventsListingMapper;
-        this.bundle = bundle;
         this.contentLogger = contentLogger;
         this.spotlightMapper = spotlightMapper;
     }
@@ -95,8 +93,7 @@ public class PageAssembler {
         return (Page) request.getAttribute("document");
     }
 
-    public void addModules(HstRequest request) {
-        PageCompositionHelper page = new PageCompositionHelper(bundle, request);
+    public void addModules(HstRequest request, PageCompositionHelper page) {
 
         for (BaseDocument item : documentUtils.getAllowedDocuments(getDocument(request))) {
             try {

--- a/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageAssembler.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageAssembler.java
@@ -9,7 +9,6 @@ import com.visitscotland.brxm.model.Module;
 import com.visitscotland.brxm.model.megalinks.LinksModule;
 import com.visitscotland.brxm.model.megalinks.SingleImageLinksModule;
 import com.visitscotland.brxm.services.DocumentUtilsService;
-import com.visitscotland.brxm.services.ResourceBundleService;
 import com.visitscotland.utils.Contract;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.slf4j.Logger;
@@ -37,7 +36,6 @@ public class PageAssembler {
     //Factories
     private final MegalinkMapper megalinkMapper;
     private final ICentreMapper iCentreMapper;
-    private final IKnowMapper iKnowMapper;
     private final ArticleMapper articleMapper;
     private final UserGeneratedContentMapper userGeneratedContentMapper;
     private final TravelInformationMapper travelInformationMapper;
@@ -58,7 +56,7 @@ public class PageAssembler {
 
     @Autowired
     public PageAssembler(DocumentUtilsService documentUtils, MegalinkMapper megalinkMapper, ICentreMapper iCentreMapper,
-                         IKnowMapper iKnowMapper, ArticleMapper articleMapper,
+                         ArticleMapper articleMapper,
                          UserGeneratedContentMapper userGeneratedContentMapper,
                          TravelInformationMapper travelInformationMapper, PreviewWarningMapper previewWarningMapper,
                          MapModuleMapper mapModuleMapper, SkiCentreMapper skiCentreMapper, SkiCentreListMapper
@@ -69,7 +67,6 @@ public class PageAssembler {
         this.documentUtils = documentUtils;
         this.megalinkMapper = megalinkMapper;
         this.iCentreMapper = iCentreMapper;
-        this.iKnowMapper = iKnowMapper;
         this.articleMapper = articleMapper;
         this.userGeneratedContentMapper = userGeneratedContentMapper;
         this.travelInformationMapper = travelInformationMapper;

--- a/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageAssembler.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageAssembler.java
@@ -65,8 +65,7 @@ public class PageAssembler {
                          skiCentreListMapper, DevModuleMapper devModuleMapper, LongCopyMapper longCopyMapper,
                          CannedSearchMapper cannedSearchMapper, CannedSearchDMSMapper cannedSearchDMSMapper,
                          FormMapper formMapper, CTABannerMapper ctaBannerMapper, EventsListingMapper eventsListingMapper,
-                         ResourceBundleService bundle, Logger contentLogger,
-                         SpotlightMapper spotlightMapper) {
+                         Logger contentLogger, SpotlightMapper spotlightMapper) {
         this.documentUtils = documentUtils;
         this.megalinkMapper = megalinkMapper;
         this.iCentreMapper = iCentreMapper;

--- a/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageCompositionException.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageCompositionException.java
@@ -3,14 +3,14 @@ package com.visitscotland.brxm.pagebuilder;
 public class PageCompositionException extends Exception {
 
     public PageCompositionException(String message) {
-        super(String.format("There has been an error composing the page: \n %s", message));
+        super(String.format("There has been an error composing the page: %n %s", message));
     }
 
     public PageCompositionException(String path, String message) {
-        super(String.format("There has been an issue mapping the document at '%s': \n %s", path, message));
+        super(String.format("There has been an issue mapping the document at '%s': %n %s", path, message));
     }
 
     public PageCompositionException(String path, String message, Exception e) {
-        super(String.format("There has been an issue mapping the document at '%s': \n %s", path, message), e);
+        super(String.format("There has been an issue mapping the document at '%s': %n %s", path, message), e);
     }
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageTemplateBuilder.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/pagebuilder/PageTemplateBuilder.java
@@ -4,7 +4,6 @@ import com.visitscotland.brxm.mapper.*;
 import com.visitscotland.brxm.mapper.module.*;
 import com.visitscotland.brxm.services.DocumentUtilsService;
 import com.visitscotland.brxm.services.ResourceBundleService;
-import com.visitscotland.brxm.utils.SiteProperties;
 import org.slf4j.Logger;
 
 /**
@@ -16,6 +15,6 @@ import org.slf4j.Logger;
 public final class PageTemplateBuilder extends PageAssembler {
 
     public PageTemplateBuilder(DocumentUtilsService documentUtils, MegalinkMapper megalinkMapper, ICentreMapper iCentreMapper, IKnowMapper iKnowMapper, ArticleMapper articleMapper, UserGeneratedContentMapper userGeneratedContentMapper, TravelInformationMapper travelInformationMapper, PreviewWarningMapper previewWarningMapper, MapModuleMapper mapModuleMapper, SkiCentreMapper skiCentreMapper, SkiCentreListMapper skiCentreListMapper, DevModuleMapper devModuleMapper, LongCopyMapper longCopyMapper, CannedSearchMapper cannedSearchMapper, CannedSearchDMSMapper cannedSearchDMSMapper, FormMapper formMapper, CTABannerMapper ctaBannerMapper, EventsListingMapper eventsListingMapper, ResourceBundleService bundle, Logger contentLogger, SpotlightMapper spotlightMapper) {
-        super(documentUtils, megalinkMapper, iCentreMapper, iKnowMapper, articleMapper, userGeneratedContentMapper, travelInformationMapper, previewWarningMapper, mapModuleMapper, skiCentreMapper, skiCentreListMapper, devModuleMapper, longCopyMapper, cannedSearchMapper, cannedSearchDMSMapper, formMapper, ctaBannerMapper, eventsListingMapper, bundle, contentLogger, spotlightMapper);
+        super(documentUtils, megalinkMapper, iCentreMapper, articleMapper, userGeneratedContentMapper, travelInformationMapper, previewWarningMapper, mapModuleMapper, skiCentreMapper, skiCentreListMapper, devModuleMapper, longCopyMapper, cannedSearchMapper, cannedSearchDMSMapper, formMapper, ctaBannerMapper, eventsListingMapper, contentLogger, spotlightMapper);
     }
 }

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/SiteProperties.java
@@ -47,8 +47,7 @@ public class SiteProperties extends Properties {
     private static final String PATH_BANNER = "site.path.banner";
     private static final String GOOGLE_MAPS_API_KEY = "google-maps.api-key";
     static final String EVENTS_LISTINGS_PAGE_SIZE = "events-listings.page-size";
-    static final String CLUDO_API = "cludo.experience-id";
-    static final String EVENTS_ENDPOINT = "events.endpoint";
+
 
     //GTM Properties
     public static final String GTM_CONTAINER_ID = "gtm.container-id";
@@ -70,6 +69,8 @@ public class SiteProperties extends Properties {
 
     //Feature switch
     private static final String GLOBAL_SEARCH_ENABLED = "feature.global-search.enable";
+    private static final String GLOBAL_SEARCH_DMS_BASED = "feature.global-search.dms-based";
+    private static final String GLOBAL_SEARCH_EVENTS_ENDPOINT = "feature.global-search.events-endpoint";
     private static final String FEATURE_HERO_SECTION = "feature.hero-section.enable";
     private static final String PRODUCTS_SEARCH_ENABLED = "feature.products-search.enable";
     private static final String TABLE_OF_CONTENTS_ENABLED = "feature.table-of-contents.enable";
@@ -171,11 +172,18 @@ public class SiteProperties extends Properties {
         return readBoolean(GLOBAL_SEARCH_ENABLED);
     }
 
+    public boolean isGlobalSearchDmsBased() {
+        return readBoolean(GLOBAL_SEARCH_DMS_BASED);
+    }
+
+    public Optional<String> getGlobalSearchEventsEndpoint() {
+        return readOptionalString(GLOBAL_SEARCH_EVENTS_ENDPOINT);
+    }
+
     public List<String> getInternalSites() {
         String sites = readString(INTERNAL_SITES);
         if (!Contract.isEmpty(sites)){
-            // TODO Java 11: Replace & Test: Arrays.stream(sites.trim().split("\\s*,\\s*")).filter(Predicate.not(String::isEmpty)).collect(Collectors.toUnmodifiableList());
-            return Arrays.stream(sites.trim().split("\\s*,\\s*")).filter(((Predicate<String>) String::isEmpty).negate()).collect(Collectors.toList());
+            return Arrays.stream(sites.trim().split("\\s*,\\s*")).filter(Predicate.not(String::isEmpty)).collect(Collectors.toUnmodifiableList());
         }
         return Collections.emptyList();
     }
@@ -183,14 +191,6 @@ public class SiteProperties extends Properties {
     @Deprecated
     public String getFormsMarketoUrl() {
         return readString(FORMS_MARKETO_URL);
-    }
-
-    public String getEventsEndpoint() {
-        return readString(EVENTS_ENDPOINT);
-    }
-
-    public String getCludoApi() {
-        return readString(CLUDO_API);
     }
 
     /**

--- a/site/components/src/test/java/com/visitscotland/brxm/pagebuilder/PageAssemblerTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/pagebuilder/PageAssemblerTest.java
@@ -86,7 +86,7 @@ class PageAssemblerTest {
     void pageWithoutElements() {
         when(utils.getAllowedDocuments(page)).thenReturn(Collections.emptyList());
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         List<?> items = (List<?>) request.getAttribute(PageAssembler.PAGE_ITEMS);
 
@@ -105,7 +105,7 @@ class PageAssemblerTest {
         when(utils.getAllowedDocuments(page)).thenReturn(Collections.singletonList(megalinks));
         doReturn(module).when(megalinkMapper).getMegalinkModule(megalinks, Locale.UK);
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
         List<?> items = (List<?>) request.getAttribute(PageAssembler.PAGE_ITEMS);
 
         assertEquals(1, items.size());
@@ -127,7 +127,7 @@ class PageAssemblerTest {
         when(previewModeFactory.createErrorModule(any())).thenReturn(new Module<>());
 
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
         List<?> items = (List<?>) request.getAttribute(PageAssembler.PAGE_ITEMS);
 
         assertEquals(1, items.size());
@@ -156,8 +156,7 @@ class PageAssemblerTest {
         doReturn(module3).when(megalinkMapper).getMegalinkModule((Megalinks) list.get(2), Locale.UK);
         doReturn(module4).when(megalinkMapper).getMegalinkModule((Megalinks) list.get(3), Locale.UK);
 
-
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
         List<LinksModule<?>> items = request.getModel(PageAssembler.PAGE_ITEMS);
 
         assertEquals(4, items.size());
@@ -192,7 +191,7 @@ class PageAssemblerTest {
         doReturn(module4).when(megalinkMapper).getMegalinkModule((Megalinks) list.get(3), Locale.UK);
 
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
         List<?> items = request.getModel(PageAssembler.PAGE_ITEMS);
 
         assertEquals(4, items.size());
@@ -217,11 +216,11 @@ class PageAssemblerTest {
         LinksModule<?> module2 = new LinksModuleMockBuilder().withLink(mock(EnhancedLink.class)).title("h2").build();
         doReturn(module1).when(megalinkMapper).getMegalinkModule(mega, Locale.UK);
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         // Build the second case where the first element has a title
         doReturn(module2).when(megalinkMapper).getMegalinkModule(mega, Locale.UK);
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         verify(module1).setThemeIndex(0);
         verify(module2).setThemeIndex(0);
@@ -252,7 +251,7 @@ class PageAssemblerTest {
         doReturn(module4).when(megalinkMapper).getMegalinkModule((Megalinks) list.get(3), Locale.UK);
 
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
         List<?> items = request.getModel(PageAssembler.PAGE_ITEMS);
         assertEquals(4, items.size());
 
@@ -271,7 +270,7 @@ class PageAssemblerTest {
 
         doReturn(new LinksModuleMockBuilder().withLink(mock(EnhancedLink.class)).build()).when(megalinkMapper).getMegalinkModule(mega, Locale.UK);
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
         LinksModule<?> module = (LinksModule<?>) ((List<?>) request.getModel(PageAssembler.PAGE_ITEMS)).get(0);
 
         assertNotNull(request.getAttribute(PageAssembler.INTRO_THEME));
@@ -283,7 +282,7 @@ class PageAssemblerTest {
     void setIntroTheme_forNonMegalinks(){
         when(utils.getAllowedDocuments(page)).thenReturn(Collections.emptyList());
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         assertNull(request.getAttribute(PageAssembler.INTRO_THEME));
     }
@@ -302,7 +301,7 @@ class PageAssemblerTest {
         when(utils.getAllowedDocuments(page)).thenReturn(Collections.singletonList(longCopy));
         when(longCopyMapper.getModule(any(LongCopy.class))).thenReturn(new LongCopyModule());
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         //List<Module> items = (List<Module>) request.getAttribute(PageTemplateBuilder.PAGE_ITEMS);
         LongCopyModule module = (LongCopyModule) ((List<Module>) request.getModel(PageAssembler.PAGE_ITEMS)).get(0);
@@ -320,7 +319,7 @@ class PageAssemblerTest {
 
         when(utils.getAllowedDocuments(page)).thenReturn(Collections.singletonList(longCopy));
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         assertEquals(0, ((List<?>) request.getModel(PageAssembler.PAGE_ITEMS)).stream().filter(m -> m instanceof LongCopyModule).count());
     }
@@ -338,7 +337,7 @@ class PageAssemblerTest {
 
         when(utils.getAllowedDocuments(page)).thenReturn(Collections.singletonList(longCopy));
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         assertEquals(0,((List<?>) request.getAttribute(PageAssembler.PAGE_ITEMS)).stream().filter(m -> !(m instanceof ErrorModule)).count());
     }
@@ -356,7 +355,7 @@ class PageAssemblerTest {
         when(utils.getAllowedDocuments(page)).thenReturn(Arrays.asList(mock(LongCopy.class), mock(LongCopy.class), mock(LongCopy.class)));
         when(longCopyMapper.getModule(any(LongCopy.class))).thenReturn(new LongCopyModule());
 
-        builder.addModules(request);
+        builder.addModules(request, new PageCompositionHelper(bundle, request));
 
         assertEquals(1, ((List<?>) request.getModel(PageAssembler.PAGE_ITEMS)).stream().filter(m -> m instanceof LongCopyModule).count());
     }


### PR DESCRIPTION
I moved the creation of PageConfigurationHelper to the PageContentComponent level so it’s accessible across all pages. This makes it easier to inject additional configuration details where needed.

Added the ability to switch between DMS-based search and Google-based search, giving us flexibility in how searches are performed.